### PR TITLE
Fix doctest in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,12 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let stream = TcpStream::connect("http.sandbox.drogue.cloud:443").await.expect("error creating TCP connection");
+//!     let stream = TcpStream::connect("https://sandbox.drogue.cloud:443").await.expect("error creating TCP connection");
 //!
 //!     println!("TCP connection opened");
 //!     let mut record_buffer = [0; 16384];
 //!     let tls_context = TlsContext::new(OsRng, &mut record_buffer)
-//!         .with_server_name("http.sandbox.drogue.cloud");
+//!         .with_server_name("sandbox.drogue.cloud");
 //!     let mut tls: TlsConnection<OsRng, TcpStream, Aes128GcmSha256> =
 //!         TlsConnection::new(tls_context, stream);
 //!


### PR DESCRIPTION
Currently the doctest in lib.rs is failing with the following error:
```console
   Doc-tests drogue-tls

running 1 test
test src/lib.rs - (line 23) ... FAILED

failures:

---- src/lib.rs - (line 23) stdout ----
Test executable failed (exit code 101).

stdout:
TCP connection opened

stderr:
thread 'main' panicked at 'error establishing TLS connection:
Unimplemented', src/lib.rs:21:22
note: run with `RUST_BACKTRACE=1` environment variable to display a
backtrace

failures:
    src/lib.rs - (line 23)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured;
 0 filtered out; finished in 1.16s
```
This commit updates the connect string to reflect what I think might be
changes on the cloud side.