### PR TITLE
Change /target to target in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target
 Cargo.lock


### PR DESCRIPTION
Currently subdirectories like examples have target directories that are
not ignored by the current rule. This commit updates the rule to ignore
simply 'target' directories.