### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/signature_schemes.rs
+++ b/src/signature_schemes.rs
@@ -122,8 +122,8 @@ impl TryInto<&'static webpki::SignatureAlgorithm> for SignatureScheme {
             SignatureScheme::RsaPssRsaeSha512 => Ok(&webpki::RSA_PSS_2048_8192_SHA512_LEGACY_KEY),
 
             /* EdDSA algorithms */
-            Ed25519 => Ok(&webpki::ED25519),
-            Ed448 => Err(TlsError::InvalidSignatureScheme),
+            SignatureScheme::Ed25519 => Ok(&webpki::ED25519),
+            SignatureScheme::Ed448 => Err(TlsError::InvalidSignatureScheme),
 
             /* RSASSA-PSS algorithms with public key OID RSASSA-PSS */
             SignatureScheme::RsaPssPssSha256 => Err(TlsError::InvalidSignatureScheme),

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -6,7 +6,7 @@ use crate::handshake::{
 use crate::TlsError;
 use core::convert::TryFrom;
 use core::convert::TryInto;
-use webpki::{DnsNameRef, Error as PkiError};
+use webpki::{DnsNameRef};
 
 static ALL_SIGALGS: &[&webpki::SignatureAlgorithm] = &[
     &webpki::ECDSA_P256_SHA256,
@@ -123,12 +123,10 @@ where
         host_verified = true;
     }
     if !verified && config.verify_cert {
-        panic!("CERT NOT VERIFIED");
         return Err(TlsError::InvalidCertificate);
     }
 
     if !host_verified && config.verify_host {
-        panic!("HOST NOT VERIFIED");
         return Err(TlsError::InvalidCertificate);
     }
     Ok(())


### PR DESCRIPTION
Currently there are a few compiler warnings:
<details><summary>compiler warnings</summary>

```console
warning: unused import: `Error as PkiError`
 --> src/verify.rs:9:26
  |
9 | use webpki::{DnsNameRef, Error as PkiError};
  |                          ^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unreachable statement
   --> src/verify.rs:127:9
    |
126 |         panic!("CERT NOT VERIFIED");
    |         ---------------------------- any code following this expression is unreachable
127 |         return Err(TlsError::InvalidCertificate);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
    = note: `#[warn(unreachable_code)]` on by default

warning: unreachable statement
   --> src/verify.rs:132:9
    |
131 |         panic!("HOST NOT VERIFIED");
    |         ---------------------------- any code following this expression is unreachable
132 |         return Err(TlsError::InvalidCertificate);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement

warning[E0170]: pattern binding `Ed25519` is named the same as one of the variants of the type `SignatureScheme`
   --> src/signature_schemes.rs:125:13
    |
125 |             Ed25519 => Ok(&webpki::ED25519),
    |             ^^^^^^^ help: to match on the variant, qualify the path: `SignatureScheme::Ed25519`
    |
    = note: `#[warn(bindings_with_variant_name)]` on by default

warning[E0170]: pattern binding `Ed448` is named the same as one of the variants of the type `SignatureScheme`
   --> src/signature_schemes.rs:126:13
    |
126 |             Ed448 => Err(TlsError::InvalidSignatureScheme),
    |             ^^^^^ help: to match on the variant, qualify the path: `SignatureScheme::Ed448`

warning: unreachable pattern
   --> src/signature_schemes.rs:126:13
    |
125 |             Ed25519 => Ok(&webpki::ED25519),
    |             ------- matches any value
126 |             Ed448 => Err(TlsError::InvalidSignatureScheme),
    |             ^^^^^ unreachable pattern
    |
    = note: `#[warn(unreachable_patterns)]` on by default

warning: unreachable pattern
   --> src/signature_schemes.rs:129:13
    |
125 |             Ed25519 => Ok(&webpki::ED25519),
    |             ------- matches any value
...
129 |             SignatureScheme::RsaPssPssSha256 => Err(TlsError::InvalidSignatureScheme),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern

warning: unreachable pattern
   --> src/signature_schemes.rs:130:13
    |
125 |             Ed25519 => Ok(&webpki::ED25519),
    |             ------- matches any value
...
130 |             SignatureScheme::RsaPssPssSha384 => Err(TlsError::InvalidSignatureScheme),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern

warning: unreachable pattern
   --> src/signature_schemes.rs:131:13
    |
125 |             Ed25519 => Ok(&webpki::ED25519),
    |             ------- matches any value
...
131 |             SignatureScheme::RsaPssPssSha512 => Err(TlsError::InvalidSignatureScheme),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern

warning: unreachable pattern
   --> src/signature_schemes.rs:134:13
    |
125 |             Ed25519 => Ok(&webpki::ED25519),
    |             ------- matches any value
...
134 |             SignatureScheme::RsaPkcs1Sha1 => Err(TlsError::InvalidSignatureScheme),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern

warning: unreachable pattern
   --> src/signature_schemes.rs:135:13
    |
125 |             Ed25519 => Ok(&webpki::ED25519),
    |             ------- matches any value
...
135 |             SignatureScheme::EcdsaSha1 => Err(TlsError::InvalidSignatureScheme),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern

warning: unused variable: `Ed25519`
   --> src/signature_schemes.rs:125:13
    |
125 |             Ed25519 => Ok(&webpki::ED25519),
    |             ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Ed25519`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `Ed448`
   --> src/signature_schemes.rs:126:13
    |
126 |             Ed448 => Err(TlsError::InvalidSignatureScheme),
    |             ^^^^^ help: if this is intentional, prefix it with an underscore: `_Ed448`

For more information about this error, try `rustc --explain E0170`.
warning: `drogue-tls` (lib) generated 13 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 18.24s

```
</details>