### PR TITLE
Remove unused imports from lib.rs doctest code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,7 @@
 //!
 //! ```
 //! use drogue_tls::*;
-//! use core::future::Future;
 //! use rand::rngs::OsRng;
-//! use std::error::Error;
-//! use tokio::io::{AsyncReadExt, AsyncWriteExt};
 //! use tokio::net::TcpStream;
 //!
 //! #[tokio::main]


### PR DESCRIPTION
This commit removes a few unused imports from the doctest code in
lib.rs. While these warnings are not displayed during a normal
build/test, if the example code is copied and built the following
warnings can be seen:
```console
$ cargo build --bin sampletls
   Compiling drogue-tls v0.2.0
warning: unused import: `core::future::Future`
 --> src/beve.rs:2:6
  |
2 |  use core::future::Future;
  |      ^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::error::Error`
 --> src/beve.rs:4:6
  |
4 |  use std::error::Error;
  |      ^^^^^^^^^^^^^^^^^

warning: unused imports: `AsyncReadExt`, `AsyncWriteExt`
 --> src/beve.rs:5:18
  |
5 |  use tokio::io::{AsyncReadExt, AsyncWriteExt};
  |                  ^^^^^^^^^^^^  ^^^^^^^^^^^^^

warning: `drogue-tls` (bin "sampletls") generated 3 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 1.56s
```