### PR TITLE
aes-gcm: 0.9.4 -> 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand_core = { version = "0.6.3", default-features = false }
 hkdf = "0.12.3"
 hmac = "0.12.1"
 sha2 = { version = "0.10.2", default-features = false }
-aes-gcm = { version = "0.9.4", default-features = false, features = ["aes"] }
+aes-gcm = { version = "0.10.1", default-features = false, features = ["aes"] }
 digest = { version = "0.10.3", default-features = false, features = ["core-api"] }
 typenum = { version = "1.15.0", default-features = false }
 heapless = { version = "0.7", default-features = false }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use crate::cipher_suites::CipherSuite;
 use crate::max_fragment_length::MaxFragmentLength;
 use crate::named_groups::NamedGroup;
 use crate::signature_schemes::SignatureScheme;
-use aes_gcm::{AeadInPlace, Aes128Gcm, NewAead};
+use aes_gcm::{AeadInPlace, Aes128Gcm, KeyInit};
 use core::marker::PhantomData;
 use digest::core_api::BlockSizeUser;
 use digest::{Digest, FixedOutput, OutputSizeUser, Reset};
@@ -16,7 +16,7 @@ const TLS_RECORD_MAX: usize = 16384;
 
 pub trait TlsCipherSuite {
     const CODE_POINT: u16;
-    type Cipher: NewAead<KeySize = Self::KeyLen> + AeadInPlace<NonceSize = Self::IvLen>;
+    type Cipher: KeyInit<KeySize = Self::KeyLen> + AeadInPlace<NonceSize = Self::IvLen>;
     type KeyLen: ArrayLength<u8>;
     type IvLen: ArrayLength<u8>;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -41,7 +41,7 @@ use crate::content_types::ContentType;
 // use crate::handshake::new_session_ticket::NewSessionTicket;
 // use crate::handshake::server_hello::ServerHello;
 use crate::parse_buffer::ParseBuffer;
-use aes_gcm::aead::{AeadCore, AeadInPlace, NewAead};
+use aes_gcm::aead::{AeadCore, AeadInPlace, KeyInit};
 use digest::OutputSizeUser;
 use heapless::spsc::Queue;
 


### PR DESCRIPTION
Relevant changelogs:
* `aead`: https://github.com/RustCrypto/traits/blob/610a26f8997052ede9013a952b84c1b44826efc3/aead/CHANGELOG.md
* `aes-gcm`: https://github.com/RustCrypto/AEADs/blob/c5c199953aba561261bed1c55f62b9c19d0f49cf/aes-gcm/CHANGELOG.md
* `aes`: https://github.com/RustCrypto/block-ciphers/blob/77bafd9fb5f629b3dc62ab6a2d105cbe1f715944/aes/CHANGELOG.md