### PR TITLE
Return ownership of socket regardless of close error

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -208,10 +208,12 @@ where
         Ok(())
     }
 
-    /// Close a connection instance, returning the ownership of the config, random generator and the async I/O provider.
-    pub async fn close(mut self) -> Result<Socket, TlsError> {
-        self.close_internal().await?;
-        Ok(self.delegate)
+    /// Close a connection instance, returning the ownership of the async I/O provider.
+    pub async fn close(mut self) -> Result<Socket, (Socket, TlsError)> {
+        match self.close_internal().await {
+            Ok(()) => Ok(self.delegate),
+            Err(e) => Err((self.delegate, e))
+        }
     }
 }
 

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -76,7 +76,7 @@ async fn test_ping() {
     assert_eq!(b"ping", &rx_buf[..sz]);
     log::info!("Read {} bytes: {:?}", sz, &rx_buf[..sz]);
 
-    tls.close().await.expect("error closing session");
+    tls.close().await.map_err(|(_, e)| e).expect("error closing session");
 }
 
 #[test]
@@ -111,5 +111,5 @@ fn test_blocking_ping() {
     assert_eq!(b"ping", &rx_buf[..sz]);
     log::info!("Read {} bytes: {:?}", sz, &rx_buf[..sz]);
 
-    tls.close().expect("error closing session");
+    tls.close().map_err(|(_, e)| e).expect("error closing session");
 }


### PR DESCRIPTION
Improve close method of TlsConnection to always return underlying socket.