### PR TITLE
Update env_logger to v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = "0.10"
 tokio = { version = "1.7", features = ["full"] }
 mio = { version = "0.8.3", features = ["os-poll", "net"] }
 rustls = "0.20.6"

--- a/examples/blocking/Cargo.toml
+++ b/examples/blocking/Cargo.toml
@@ -11,6 +11,6 @@ authors = [
 embedded-tls = { path = "../..", features = ["log", "std", "webpki"], default-features = false }
 embedded-io = { version = "0.4.0", features = ["std"] }
 pem-parser = "0.1"
-env_logger = "0.8"
+env_logger = "0.10"
 rand = "0.8"
 log = "0.4"

--- a/examples/embassy/Cargo.toml
+++ b/examples/embassy/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [dependencies]
 embedded-tls = { path = "../..", features = ["async", "std", "log"], default-features = false }
-env_logger = "0.9"
+env_logger = "0.10"
 rand = "0.8"
 log = "0.4"
 static_cell = "1"

--- a/examples/tokio-psk/Cargo.toml
+++ b/examples/tokio-psk/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 embedded-tls = { path = "../..", features = ["log", "tokio"] }
 embedded-io = { version = "0.4.0", features = ["tokio"] }
-env_logger = "0.8"
+env_logger = "0.10"
 tokio = { version = "1.7", features = ["full"] }
 rand = "0.8"
 log = "0.4"

--- a/examples/tokio/Cargo.toml
+++ b/examples/tokio/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 [dependencies]
 embedded-tls = { path = "../..", features = ["log", "tokio"] }
 embedded-io = { version = "0.4.0", features = ["tokio"] }
-env_logger = "0.8"
+env_logger = "0.10"
 tokio = { version = "1.7", features = ["full"] }
 rand = "0.8"
 log = "0.4"


### PR DESCRIPTION
Release notes: https://github.com/rust-cli/env_logger/blob/v0.10.0/CHANGELOG.md#0100---2022-11-24