### PR TITLE
Update rustls-mio url and command

### DIFF
--- a/examples/blocking/README.md
+++ b/examples/blocking/README.md
@@ -2,13 +2,13 @@
 
 This example show how you can use embedded-tls with standard std Read/Write traits. It will attempt to connect to an endpoint, send a "ping" message, and expect a "pong" response.
 
-You can use the [rustls-mio](https://github.com/ctz/rustls/tree/main/rustls-mio) server example to test it as follows:
+You can use the [rustls-mio](https://github.com/rustls/rustls/tree/main/examples) server example to test it as follows:
 
 
 ```sh
 # In the rustls-mio folder
 openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout key.pem -out cert.pem -batch
-cargo run --example tlsserver -- -p 12345 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
+cargo run --bin tlsserver-mio -- -p 8000 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
 
 # In this folder
 RUST_LOG=trace cargo run

--- a/examples/blocking/README.md
+++ b/examples/blocking/README.md
@@ -8,7 +8,7 @@ You can use the [rustls-mio](https://github.com/rustls/rustls/tree/main/examples
 ```sh
 # In the rustls-mio folder
 openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout key.pem -out cert.pem -batch
-cargo run --bin tlsserver-mio -- -p 8000 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
+cargo run --bin tlsserver-mio -- -p 12345 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
 
 # In this folder
 RUST_LOG=trace cargo run

--- a/examples/embassy/README.md
+++ b/examples/embassy/README.md
@@ -19,7 +19,7 @@ You can use the [rustls-mio](https://github.com/rustls/rustls/tree/main/examples
 ```sh
 # In the rustls-mio folder
 openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout key.pem -out cert.pem -batch
-cargo run --bin tlsserver-mio -- -p 8000 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
+cargo run --bin tlsserver-mio -- -p 12345 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
 
 # In this folder
 RUST_LOG=trace cargo run

--- a/examples/embassy/README.md
+++ b/examples/embassy/README.md
@@ -14,12 +14,12 @@ sudo ip -6 route add fe80::/64 dev tap0
 sudo ip -6 route add fdaa::/64 dev tap0
 ```
 
-You can use the [rustls-mio](https://github.com/ctz/rustls/tree/main/rustls-mio) server example to test it as follows:
+You can use the [rustls-mio](https://github.com/rustls/rustls/tree/main/examples) server example to test it as follows:
 
 ```sh
 # In the rustls-mio folder
 openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout key.pem -out cert.pem -batch
-cargo run --example tlsserver -- -p 12345 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
+cargo run --bin tlsserver-mio -- -p 8000 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
 
 # In this folder
 RUST_LOG=trace cargo run

--- a/examples/embassy/src/main.rs
+++ b/examples/embassy/src/main.rs
@@ -82,7 +82,7 @@ async fn main_task(spawner: Spawner) {
 
     socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
 
-    let remote_endpoint = (Ipv4Address::new(192, 168, 69, 100), 8000);
+    let remote_endpoint = (Ipv4Address::new(192, 168, 69, 100), 12345);
     log::info!("connecting to {:?}...", remote_endpoint);
     let r = socket.connect(remote_endpoint).await;
     if let Err(e) = r {

--- a/examples/tokio/README.md
+++ b/examples/tokio/README.md
@@ -2,13 +2,13 @@
 
 This example show how you can use embedded-tls with the tokio async runtime. It will attempt to connect to an endpoint, send a "ping" message, and expect a "pong" response.
 
-You can use the [rustls-mio](https://github.com/ctz/rustls/tree/main/rustls-mio) server example to test it as follows:
+You can use the [rustls-mio](https://github.com/rustls/rustls/tree/main/examples) server example to test it as follows:
 
 
 ```sh
 # In the rustls-mio folder
 openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout key.pem -out cert.pem -batch
-cargo run --example tlsserver -- -p 12345 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
+cargo run --bin tlsserver-mio -- -p 8000 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
 
 # In this folder
 RUST_LOG=trace cargo run

--- a/examples/tokio/README.md
+++ b/examples/tokio/README.md
@@ -8,7 +8,7 @@ You can use the [rustls-mio](https://github.com/rustls/rustls/tree/main/examples
 ```sh
 # In the rustls-mio folder
 openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout key.pem -out cert.pem -batch
-cargo run --bin tlsserver-mio -- -p 8000 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
+cargo run --bin tlsserver-mio -- -p 12345 --certs cert.pem --key key.pem --protover 1.3 --tickets --verbose echo
 
 # In this folder
 RUST_LOG=trace cargo run


### PR DESCRIPTION
This [rustls-mio](https://github.com/ctz/rustls/tree/main/rustls-mio) link in README is 404 now. Update it to the example folder in official Rustls repository. Also command changed a little bit.