### PR TITLE
Buffered writes

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -32,6 +32,7 @@ where
     key_schedule: KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
     record_read_buf: &'a mut [u8],
     record_write_buf: &'a mut [u8],
+    write_pos: usize,
     decrypted_offset: usize,
     decrypted_len: usize,
     decrypted_consumed: usize,
@@ -68,6 +69,7 @@ where
             key_schedule: KeySchedule::new(),
             record_read_buf,
             record_write_buf,
+            write_pos: 0,
             decrypted_offset: 0,
             decrypted_len: 0,
             decrypted_consumed: 0,
@@ -122,35 +124,62 @@ where
     /// Encrypt and send the provided slice over the connection. The connection
     /// must be opened before writing.
     ///
-    /// Returns the number of bytes written.
+    /// The slice may be buffered internally and not written to the connection immediately.
+    /// In this case [`flush()`] should be called to force the currently buffered writes
+    /// to be written to the connection.
+    ///
+    /// Returns the number of bytes buffered/written.
     pub async fn write(&mut self, buf: &[u8]) -> Result<usize, TlsError> {
         if self.opened {
-            let mut wp = 0;
-            let mut remaining = buf.len();
-
             let max_block_size = self.record_write_buf.len() - TLS_RECORD_OVERHEAD;
-            while remaining > 0 {
-                let delegate = &mut self.delegate;
-                let key_schedule = &mut self.key_schedule;
-                let to_write = core::cmp::min(remaining, max_block_size);
-                let record: ClientRecord<'a, '_, CipherSuite> =
-                    ClientRecord::ApplicationData(&buf[wp..to_write]);
-
-                let (_, len) = encode_record(self.record_write_buf, key_schedule, &record)?;
-
-                delegate
-                    .write(&self.record_write_buf[..len])
-                    .await
-                    .map_err(|e| TlsError::Io(e.kind()))?;
-                key_schedule.increment_write_counter();
-                wp += to_write;
-                remaining -= to_write;
+            let buffered = usize::min(buf.len(), max_block_size - self.write_pos);
+            if buffered > 0 {
+                self.record_write_buf[self.write_pos..self.write_pos + buffered]
+                    .copy_from_slice(&buf[..buffered]);
+                self.write_pos += buffered;
             }
 
-            Ok(buf.len())
+            if self.write_pos == max_block_size {
+                let len = encode_application_data_record_in_place::<CipherSuite>(
+                    self.record_write_buf,
+                    self.write_pos,
+                    &mut self.key_schedule,
+                )?;
+
+                self.delegate
+                    .write_all(&self.record_write_buf[..len])
+                    .await
+                    .map_err(|e| TlsError::Io(e.kind()))?;
+
+                self.key_schedule.increment_write_counter();
+                self.write_pos = 0;
+            }
+
+            Ok(buffered)
         } else {
             Err(TlsError::MissingHandshake)
         }
+    }
+
+    /// Force all previously written, buffered bytes to be encoded into a tls record and written to the connection.
+    pub async fn flush(&mut self) -> Result<(), TlsError> {
+        if self.write_pos > 0 {
+            let len = encode_application_data_record_in_place::<CipherSuite>(
+                self.record_write_buf,
+                self.write_pos,
+                &mut self.key_schedule,
+            )?;
+
+            self.delegate
+                .write_all(&self.record_write_buf[..len])
+                .await
+                .map_err(|e| TlsError::Io(e.kind()))?;
+
+            self.key_schedule.increment_write_counter();
+            self.write_pos = 0;
+        }
+
+        Ok(())
     }
 
     /// Read and decrypt data filling the provided slice.
@@ -301,6 +330,6 @@ where
     }
 
     async fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
+        TlsConnection::flush(self).await
     }
 }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -32,6 +32,7 @@ where
     key_schedule: KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
     record_read_buf: &'a mut [u8],
     record_write_buf: &'a mut [u8],
+    write_pos: usize,
     decrypted_offset: usize,
     decrypted_len: usize,
     decrypted_consumed: usize,
@@ -68,6 +69,7 @@ where
             key_schedule: KeySchedule::new(),
             record_read_buf,
             record_write_buf,
+            write_pos: 0,
             decrypted_offset: 0,
             decrypted_len: 0,
             decrypted_consumed: 0,
@@ -120,34 +122,60 @@ where
     /// Encrypt and send the provided slice over the connection. The connection
     /// must be opened before writing.
     ///
-    /// Returns the number of bytes written.
+    /// The slice may be buffered internally and not written to the connection immediately.
+    /// In this case [`flush()`] should be called to force the currently buffered writes
+    /// to be written to the connection.
+    ///
+    /// Returns the number of bytes buffered/written.
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, TlsError> {
         if self.opened {
-            let mut wp = 0;
-            let mut remaining = buf.len();
-
             let max_block_size = self.record_write_buf.len() - TLS_RECORD_OVERHEAD;
-            while remaining > 0 {
-                let delegate = &mut self.delegate;
-                let key_schedule = &mut self.key_schedule;
-                let to_write = core::cmp::min(remaining, max_block_size);
-                let record: ClientRecord<'a, '_, CipherSuite> =
-                    ClientRecord::ApplicationData(&buf[wp..to_write]);
-
-                let (_, len) = encode_record(self.record_write_buf, key_schedule, &record)?;
-
-                delegate
-                    .write(&self.record_write_buf[..len])
-                    .map_err(|e| TlsError::Io(e.kind()))?;
-                key_schedule.increment_write_counter();
-                wp += to_write;
-                remaining -= to_write;
+            let buffered = usize::min(buf.len(), max_block_size - self.write_pos);
+            if buffered > 0 {
+                self.record_write_buf[self.write_pos..self.write_pos + buffered]
+                    .copy_from_slice(&buf[..buffered]);
+                self.write_pos += buffered;
             }
 
-            Ok(buf.len())
+            if self.write_pos == max_block_size {
+                let len = encode_application_data_record_in_place::<CipherSuite>(
+                    self.record_write_buf,
+                    self.write_pos,
+                    &mut self.key_schedule,
+                )?;
+
+                self.delegate
+                    .write_all(&self.record_write_buf[..len])
+                    .map_err(|e| TlsError::Io(e.kind()))?;
+
+                self.key_schedule.increment_write_counter();
+                self.write_pos = 0;
+            }
+
+            Ok(buffered)
         } else {
             Err(TlsError::MissingHandshake)
         }
+    }
+
+    /// Force all previously written, buffered bytes to be encoded into a tls record and written to the connection.
+    pub fn flush(&mut self) -> Result<(), TlsError> {
+        if self.write_pos > 0 {
+            let len = encode_application_data_record_in_place::<CipherSuite>(
+                self.record_write_buf,
+                self.write_pos,
+                &mut self.key_schedule,
+            )?;
+
+            self.delegate
+                .write_all(&self.record_write_buf[..len])
+                .map_err(|e| TlsError::Io(e.kind()))?;
+
+            self.key_schedule.increment_write_counter();
+            self.write_pos = 0;
+        }
+
+        Ok(())
     }
 
     /// Read and decrypt data filling the provided slice. The slice must be able to
@@ -294,6 +322,6 @@ where
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
+        TlsConnection::flush(self)
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,7 @@
 use crate::config::{TlsCipherSuite, TlsConfig, TlsVerifier};
 use crate::handshake::{ClientHandshake, ServerHandshake};
 use crate::key_schedule::KeySchedule;
-use crate::record::{ClientRecord, RecordHeader, ServerRecord};
+use crate::record::{encode_application_data_in_place, ClientRecord, RecordHeader, ServerRecord};
 use crate::TlsError;
 use crate::{
     alert::*,
@@ -223,6 +223,19 @@ where
     }
 
     Ok((next_hash, len))
+}
+
+pub fn encode_application_data_record_in_place<'m, CipherSuite>(
+    tx_buf: &mut [u8],
+    data_len: usize,
+    key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+) -> Result<usize, TlsError>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    encode_application_data_in_place(tx_buf, data_len, |buf| {
+        encrypt::<CipherSuite>(key_schedule, buf)
+    })
 }
 
 #[cfg(feature = "async")]

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -72,6 +72,7 @@ async fn test_ping() {
         core::mem::size_of_val(&write_fut)
     );
     write_fut.await.expect("error writing data");
+    tls.flush().await.expect("error flushing data");
 
     let mut rx_buf = [0; 4096];
     let read_fut = tls.read(&mut rx_buf);
@@ -115,6 +116,7 @@ fn test_blocking_ping() {
     log::info!("Established");
 
     tls.write(b"ping").expect("error writing data");
+    tls.flush().expect("error flushing data");
 
     let mut rx_buf = [0; 4096];
     let sz = tls.read(&mut rx_buf).expect("error reading data");

--- a/tests/psk_test.rs
+++ b/tests/psk_test.rs
@@ -92,6 +92,7 @@ async fn test_psk_open() {
         println!("TLS session opened");
 
         tls.write(b"ping").await.unwrap();
+        tls.flush().await.unwrap();
 
         println!("TLS data written");
         let mut rx = [0; 4];


### PR DESCRIPTION
Important: This is a breaking change!

Previous behavior:
TlsConnection::write() was by itself flush'ing in nature, in that, no matter the buffer to be written, it encoded it as a tls record and wrote it to the connection immediately.

New behavior:
TlsConnection::write() now buffer any writes to create larger tls records which in turn reduces overhead and bandwidth. To ensure that the last record is actually written, one must call TlsConnection::flush().