### PR TITLE
Use entire rx_buf while reading from transport

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -4,6 +4,7 @@ use crate::connection::*;
 use crate::handshake::ServerHandshake;
 use crate::key_schedule::KeySchedule;
 use crate::record::{ClientRecord, ServerRecord};
+use crate::record_reader::RecordReader;
 use crate::TlsError;
 use embedded_io::Error as _;
 use embedded_io::{
@@ -30,9 +31,8 @@ where
     delegate: Socket,
     opened: bool,
     key_schedule: KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
-    record_read_buf: &'a mut [u8],
+    record_reader: RecordReader<'a, CipherSuite>,
     record_write_buf: &'a mut [u8],
-    read_remainder: Remainder,
     write_pos: usize,
     decrypted_offset: usize,
     decrypted_len: usize,
@@ -68,9 +68,8 @@ where
             delegate,
             opened: false,
             key_schedule: KeySchedule::new(),
-            record_read_buf,
+            record_reader: RecordReader::new(record_read_buf),
             record_write_buf,
-            read_remainder: Remainder::default(),
             write_pos: 0,
             decrypted_offset: 0,
             decrypted_len: 0,
@@ -97,13 +96,12 @@ where
         let mut state = State::ClientHello;
 
         loop {
-            let (next_state, remainder) = state
+            let next_state = state
                 .process::<_, _, _, Verifier>(
                     &mut self.delegate,
                     &mut handshake,
-                    self.record_read_buf,
+                    &mut self.record_reader,
                     self.record_write_buf,
-                    self.read_remainder,
                     &mut self.key_schedule,
                     context.config,
                     context.rng,
@@ -111,7 +109,6 @@ where
                 .await?;
             trace!("State {:?} -> {:?}", state, next_state);
             state = next_state;
-            self.read_remainder = remainder;
             if let State::ApplicationData = state {
                 self.opened = true;
                 break;
@@ -191,7 +188,7 @@ where
                 let record_data = if consumed < self.decrypted_len {
                     // The current record is not completely consumed
                     CryptoBuffer::wrap(
-                        &mut self.record_read_buf
+                        &mut self.record_reader.buf
                             [self.decrypted_offset..self.decrypted_offset + self.decrypted_len],
                     )
                 } else {
@@ -215,21 +212,14 @@ where
     }
 
     async fn read_application_data<'m>(&'m mut self) -> Result<CryptoBuffer<'m>, TlsError> {
-        let socket = &mut self.delegate;
-        let key_schedule = &mut self.key_schedule;
-
-        let buf_ptr = self.record_read_buf.as_ptr();
-        let buf_len = self.record_read_buf.len();
-        let (record, remainder) = decode_record::<Socket, CipherSuite>(
-            socket,
-            self.record_read_buf,
-            self.read_remainder,
-            key_schedule,
-        )
-        .await?;
-        self.read_remainder = remainder;
+        let buf_ptr = self.record_reader.buf.as_ptr();
+        let buf_len = self.record_reader.buf.len();
+        let record = self
+            .record_reader
+            .read(&mut self.delegate, &mut self.key_schedule)
+            .await?;
         let mut records = Queue::new();
-        decrypt_record::<CipherSuite>(key_schedule, &mut records, record)?;
+        decrypt_record::<CipherSuite>(&mut self.key_schedule, &mut records, record)?;
 
         while let Some(record) = records.dequeue() {
             match record {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -71,6 +71,7 @@ where
             record_read_buf,
             record_write_buf,
             read_remainder: Remainder::default(),
+            write_pos: 0,
             decrypted_offset: 0,
             decrypted_len: 0,
             decrypted_consumed: 0,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -32,7 +32,7 @@ where
     key_schedule: KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
     record_read_buf: &'a mut [u8],
     record_write_buf: &'a mut [u8],
-    read_reminder: Reminder,
+    read_remainder: Remainder,
     decrypted_offset: usize,
     decrypted_len: usize,
     decrypted_consumed: usize,
@@ -69,7 +69,7 @@ where
             key_schedule: KeySchedule::new(),
             record_read_buf,
             record_write_buf,
-            read_reminder: Reminder::default(),
+            read_remainder: Remainder::default(),
             decrypted_offset: 0,
             decrypted_len: 0,
             decrypted_consumed: 0,
@@ -95,19 +95,19 @@ where
         let mut state = State::ClientHello;
 
         loop {
-            let (next_state, reminder) = state.process_blocking::<_, _, _, Verifier>(
+            let (next_state, remainder) = state.process_blocking::<_, _, _, Verifier>(
                 &mut self.delegate,
                 &mut handshake,
                 self.record_read_buf,
                 self.record_write_buf,
-                self.read_reminder,
+                self.read_remainder,
                 &mut self.key_schedule,
                 context.config,
                 context.rng,
             )?;
             trace!("State {:?} -> {:?}", state, next_state);
             state = next_state;
-            self.read_reminder = reminder;
+            self.read_remainder = remainder;
             if let State::ApplicationData = state {
                 self.opened = true;
                 break;
@@ -187,13 +187,13 @@ where
     fn read_application_data<'m>(&'m mut self) -> Result<CryptoBuffer<'m>, TlsError> {
         let buf_ptr = self.record_read_buf.as_ptr();
         let buf_len = self.record_read_buf.len();
-        let (record, reminder) = decode_record_blocking::<Socket, CipherSuite>(
+        let (record, remainder) = decode_record_blocking::<Socket, CipherSuite>(
             &mut self.delegate,
             self.record_read_buf,
-            self.read_reminder,
+            self.read_remainder,
             &mut self.key_schedule,
         )?;
-        self.read_reminder = reminder;
+        self.read_remainder = remainder;
         let mut records = Queue::new();
         decrypt_record::<CipherSuite>(&mut self.key_schedule, &mut records, record)?;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -229,21 +229,21 @@ where
 async fn advance<'m>(
     transport: &mut impl AsyncRead,
     rx_buf: &'m mut [u8],
-    mut reminder: Reminder,
+    mut remainder: Remainder,
     amount: usize,
-) -> Result<(&'m mut [u8], Reminder), TlsError> {
-    if reminder.offset + amount > rx_buf.len() {
+) -> Result<(&'m mut [u8], Remainder), TlsError> {
+    if remainder.offset + amount > rx_buf.len() {
         if amount > rx_buf.len() {
             return Err(TlsError::InsufficientSpace);
         }
-        rx_buf.copy_within(reminder.offset..reminder.offset + reminder.len, 0);
-        reminder.offset = 0;
+        rx_buf.copy_within(remainder.offset..remainder.offset + remainder.len, 0);
+        remainder.offset = 0;
     }
 
-    let mut pos = reminder.len;
+    let mut pos = remainder.len;
     while pos < amount {
         let read = transport
-            .read(&mut rx_buf[reminder.offset + pos..])
+            .read(&mut rx_buf[remainder.offset + pos..])
             .await
             .map_err(|e| TlsError::Io(e.kind()))?;
         if read == 0 {
@@ -253,9 +253,9 @@ async fn advance<'m>(
     }
 
     Ok((
-        &mut rx_buf[reminder.offset..reminder.offset + amount],
-        Reminder {
-            offset: reminder.offset + amount,
+        &mut rx_buf[remainder.offset..remainder.offset + amount],
+        Remainder {
+            offset: remainder.offset + amount,
             len: pos - amount,
         },
     ))
@@ -264,21 +264,21 @@ async fn advance<'m>(
 fn advance_blocking<'m>(
     transport: &mut impl BlockingRead,
     rx_buf: &'m mut [u8],
-    mut reminder: Reminder,
+    mut remainder: Remainder,
     amount: usize,
-) -> Result<(&'m mut [u8], Reminder), TlsError> {
-    if reminder.offset + amount > rx_buf.len() {
+) -> Result<(&'m mut [u8], Remainder), TlsError> {
+    if remainder.offset + amount > rx_buf.len() {
         if amount > rx_buf.len() {
             return Err(TlsError::InsufficientSpace);
         }
-        rx_buf.copy_within(reminder.offset..reminder.offset + reminder.len, 0);
-        reminder.offset = 0;
+        rx_buf.copy_within(remainder.offset..remainder.offset + remainder.len, 0);
+        remainder.offset = 0;
     }
 
-    let mut pos = reminder.len;
+    let mut pos = remainder.len;
     while pos < amount {
         let read = transport
-            .read(&mut rx_buf[reminder.offset + pos..])
+            .read(&mut rx_buf[remainder.offset + pos..])
             .map_err(|e| TlsError::Io(e.kind()))?;
         if read == 0 {
             return Err(TlsError::IoError);
@@ -287,9 +287,9 @@ fn advance_blocking<'m>(
     }
 
     Ok((
-        &mut rx_buf[reminder.offset..reminder.offset + amount],
-        Reminder {
-            offset: reminder.offset + amount,
+        &mut rx_buf[remainder.offset..remainder.offset + amount],
+        Remainder {
+            offset: remainder.offset + amount,
             len: pos - amount,
         },
     ))
@@ -299,12 +299,12 @@ fn advance_blocking<'m>(
 pub async fn decode_record<'m, Transport, CipherSuite>(
     transport: &mut Transport,
     rx_buf: &'m mut [u8],
-    reminder: Reminder,
+    remainder: Remainder,
     key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
 ) -> Result<
     (
         ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
-        Reminder,
+        Remainder,
     ),
     TlsError,
 >
@@ -312,26 +312,26 @@ where
     Transport: AsyncRead + 'm,
     CipherSuite: TlsCipherSuite + 'static,
 {
-    let (header, reminder) = advance(transport, rx_buf, reminder, 5).await?;
+    let (header, remainder) = advance(transport, rx_buf, remainder, 5).await?;
     let header = RecordHeader::decode(header.try_into().unwrap())?;
     let content_length = header.content_length();
 
-    let (data, reminder) = advance(transport, rx_buf, reminder, content_length).await?;
+    let (data, remainder) = advance(transport, rx_buf, remainder, content_length).await?;
     Ok((
         ServerRecord::decode::<CipherSuite::Hash>(header, data, key_schedule.transcript_hash())?,
-        reminder,
+        remainder,
     ))
 }
 
 pub fn decode_record_blocking<'m, Transport, CipherSuite>(
     transport: &mut Transport,
     rx_buf: &'m mut [u8],
-    reminder: Reminder,
+    remainder: Remainder,
     key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
 ) -> Result<
     (
         ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
-        Reminder,
+        Remainder,
     ),
     TlsError,
 >
@@ -339,14 +339,14 @@ where
     Transport: BlockingRead + 'm,
     CipherSuite: TlsCipherSuite + 'static,
 {
-    let (header, reminder) = advance_blocking(transport, rx_buf, reminder, 5)?;
+    let (header, remainder) = advance_blocking(transport, rx_buf, remainder, 5)?;
     let header = RecordHeader::decode(header.try_into().unwrap())?;
     let content_length = header.content_length();
 
-    let (data, reminder) = advance_blocking(transport, rx_buf, reminder, content_length)?;
+    let (data, remainder) = advance_blocking(transport, rx_buf, remainder, content_length)?;
     Ok((
         ServerRecord::decode::<CipherSuite::Hash>(header, data, key_schedule.transcript_hash())?,
-        reminder,
+        remainder,
     ))
 }
 
@@ -388,7 +388,7 @@ pub enum State {
 }
 
 #[derive(Clone, Copy, Default)]
-pub struct Reminder {
+pub struct Remainder {
     offset: usize,
     len: usize,
 }
@@ -401,11 +401,11 @@ impl<'a> State {
         handshake: &mut Handshake<CipherSuite, Verifier>,
         rx_buf: &mut [u8],
         tx_buf: &mut [u8],
-        reminder: Reminder,
+        remainder: Remainder,
         key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
         config: &TlsConfig<'a, CipherSuite>,
         rng: &mut RNG,
-    ) -> Result<(State, Reminder), TlsError>
+    ) -> Result<(State, Remainder), TlsError>
     where
         Transport: AsyncRead + AsyncWrite + 'a,
         RNG: CryptoRng + RngCore + 'a,
@@ -428,38 +428,38 @@ impl<'a> State {
                     client_hello
                 {
                     handshake.secret.replace(client_hello.secret);
-                    Ok((State::ServerHello, reminder))
+                    Ok((State::ServerHello, remainder))
                 } else {
                     Err(TlsError::EncodeError)
                 }
             }
             State::ServerHello => {
-                let (record, reminder) = decode_record::<Transport, CipherSuite>(
+                let (record, remainder) = decode_record::<Transport, CipherSuite>(
                     transport,
                     rx_buf,
-                    reminder,
+                    remainder,
                     key_schedule,
                 )
                 .await?;
                 process_server_hello(handshake, key_schedule, record)?;
-                Ok((State::ServerVerify, reminder))
+                Ok((State::ServerVerify, remainder))
             }
             State::ServerVerify => {
                 /*info!(
                     "SIZE of server record queue : {}",
                     core::mem::size_of_val(&records)
                 );*/
-                let (record, reminder) = decode_record::<Transport, CipherSuite>(
+                let (record, remainder) = decode_record::<Transport, CipherSuite>(
                     transport,
                     rx_buf,
-                    reminder,
+                    remainder,
                     key_schedule,
                 )
                 .await?;
 
                 Ok((
                     process_server_verify::<_, Verifier>(handshake, key_schedule, config, record)?,
-                    reminder,
+                    remainder,
                 ))
             }
             State::ClientCert => {
@@ -492,7 +492,7 @@ impl<'a> State {
                     .map_err(|e| TlsError::Io(e.kind()))?;
                 key_schedule.increment_write_counter();
                 key_schedule.replace_transcript_hash(next_hash);
-                Ok((State::ClientFinished, reminder))
+                Ok((State::ClientFinished, remainder))
             }
             State::ClientFinished => {
                 let client_finished = key_schedule
@@ -517,9 +517,9 @@ impl<'a> State {
                 );
                 key_schedule.initialize_master_secret()?;
 
-                Ok((State::ApplicationData, reminder))
+                Ok((State::ApplicationData, remainder))
             }
-            State::ApplicationData => Ok((State::ApplicationData, reminder)),
+            State::ApplicationData => Ok((State::ApplicationData, remainder)),
         }
     }
 
@@ -529,11 +529,11 @@ impl<'a> State {
         handshake: &mut Handshake<CipherSuite, Verifier>,
         rx_buf: &mut [u8],
         tx_buf: &mut [u8],
-        reminder: Reminder,
+        remainder: Remainder,
         key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
         config: &TlsConfig<'a, CipherSuite>,
         rng: &mut RNG,
-    ) -> Result<(State, Reminder), TlsError>
+    ) -> Result<(State, Remainder), TlsError>
     where
         Transport: BlockingRead + BlockingWrite + 'a,
         RNG: CryptoRng + RngCore,
@@ -555,36 +555,36 @@ impl<'a> State {
                     client_hello
                 {
                     handshake.secret.replace(client_hello.secret);
-                    Ok((State::ServerHello, reminder))
+                    Ok((State::ServerHello, remainder))
                 } else {
                     Err(TlsError::EncodeError)
                 }
             }
             State::ServerHello => {
-                let (record, reminder) = decode_record_blocking::<Transport, CipherSuite>(
+                let (record, remainder) = decode_record_blocking::<Transport, CipherSuite>(
                     transport,
                     rx_buf,
-                    reminder,
+                    remainder,
                     key_schedule,
                 )?;
                 process_server_hello(handshake, key_schedule, record)?;
-                Ok((State::ServerVerify, reminder))
+                Ok((State::ServerVerify, remainder))
             }
             State::ServerVerify => {
                 /*info!(
                     "SIZE of server record queue : {}",
                     core::mem::size_of_val(&records)
                 );*/
-                let (record, reminder) = decode_record_blocking::<Transport, CipherSuite>(
+                let (record, remainder) = decode_record_blocking::<Transport, CipherSuite>(
                     transport,
                     rx_buf,
-                    reminder,
+                    remainder,
                     key_schedule,
                 )?;
 
                 Ok((
                     process_server_verify::<_, Verifier>(handshake, key_schedule, config, record)?,
-                    reminder,
+                    remainder,
                 ))
             }
             State::ClientCert => {
@@ -612,7 +612,7 @@ impl<'a> State {
                     .map_err(|e| TlsError::Io(e.kind()))?;
                 key_schedule.increment_write_counter();
                 key_schedule.replace_transcript_hash(next_hash);
-                Ok((State::ClientFinished, reminder))
+                Ok((State::ClientFinished, remainder))
             }
             State::ClientFinished => {
                 let client_finished = key_schedule
@@ -636,9 +636,9 @@ impl<'a> State {
                 );
                 key_schedule.initialize_master_secret()?;
 
-                Ok((State::ApplicationData, reminder))
+                Ok((State::ApplicationData, remainder))
             }
-            State::ApplicationData => Ok((State::ApplicationData, reminder)),
+            State::ApplicationData => Ok((State::ApplicationData, remainder)),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ mod max_fragment_length;
 mod named_groups;
 mod parse_buffer;
 mod record;
+mod record_reader;
 mod signature_schemes;
 mod supported_versions;
 

--- a/src/record_reader.rs
+++ b/src/record_reader.rs
@@ -7,9 +7,10 @@ use embedded_io::{blocking::Read as BlockingRead, Error};
 use embedded_io::asynch::Read as AsyncRead;
 
 use crate::{
+    config::TlsCipherSuite,
     key_schedule::KeySchedule,
     record::{RecordHeader, ServerRecord},
-    TlsCipherSuite, TlsError,
+    TlsError,
 };
 
 pub struct RecordReader<'a, CipherSuite>

--- a/src/record_reader.rs
+++ b/src/record_reader.rs
@@ -1,0 +1,242 @@
+use core::marker::PhantomData;
+
+use digest::OutputSizeUser;
+use embedded_io::{blocking::Read as BlockingRead, Error};
+
+#[cfg(feature = "async")]
+use embedded_io::asynch::Read as AsyncRead;
+
+use crate::{
+    key_schedule::KeySchedule,
+    record::{RecordHeader, ServerRecord},
+    TlsCipherSuite, TlsError,
+};
+
+pub struct RecordReader<'a, CipherSuite>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    pub(crate) buf: &'a mut [u8],
+    /// The number of decoded bytes in the buffer
+    decoded: usize,
+    /// The number of read but not yet decoded bytes in the buffer
+    pending: usize,
+    cipher_suite: PhantomData<CipherSuite>,
+}
+
+impl<'a, CipherSuite> RecordReader<'a, CipherSuite>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    pub fn new(buf: &'a mut [u8]) -> Self {
+        Self {
+            buf,
+            decoded: 0,
+            pending: 0,
+            cipher_suite: PhantomData,
+        }
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn read<'m>(
+        &'m mut self,
+        transport: &mut impl AsyncRead,
+        key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    ) -> Result<ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>, TlsError>
+    where
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        let header = self.advance(transport, 5).await?;
+        let header = RecordHeader::decode(header.try_into().unwrap())?;
+        let content_length = header.content_length();
+
+        let data = self.advance(transport, content_length).await?;
+        ServerRecord::decode::<CipherSuite::Hash>(header, data, key_schedule.transcript_hash())
+    }
+
+    #[cfg(feature = "async")]
+    async fn advance<'m>(
+        &'m mut self,
+        transport: &mut impl AsyncRead,
+        amount: usize,
+    ) -> Result<&'m mut [u8], TlsError> {
+        if self.decoded + amount > self.buf.len() {
+            if amount > self.buf.len() {
+                return Err(TlsError::InsufficientSpace);
+            }
+            self.buf
+                .copy_within(self.decoded..self.decoded + self.pending, 0);
+            self.decoded = 0;
+        }
+
+        while self.pending < amount {
+            let read = transport
+                .read(&mut self.buf[self.decoded + self.pending..])
+                .await
+                .map_err(|e| TlsError::Io(e.kind()))?;
+            if read == 0 {
+                return Err(TlsError::IoError);
+            }
+            self.pending += read;
+        }
+
+        let slice = &mut self.buf[self.decoded..self.decoded + amount];
+        self.decoded += amount;
+        self.pending -= amount;
+        Ok(slice)
+    }
+
+    pub fn read_blocking<'m>(
+        &'m mut self,
+        transport: &mut impl BlockingRead,
+        key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    ) -> Result<ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>, TlsError>
+    where
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        let header = self.advance_blocking(transport, 5)?;
+        let header = RecordHeader::decode(header.try_into().unwrap())?;
+        let content_length = header.content_length();
+
+        let data = self.advance_blocking(transport, content_length)?;
+        ServerRecord::decode::<CipherSuite::Hash>(header, data, key_schedule.transcript_hash())
+    }
+
+    fn advance_blocking<'m>(
+        &'m mut self,
+        transport: &mut impl BlockingRead,
+        amount: usize,
+    ) -> Result<&'m mut [u8], TlsError> {
+        if self.decoded + amount > self.buf.len() {
+            if amount > self.buf.len() {
+                return Err(TlsError::InsufficientSpace);
+            }
+            self.buf
+                .copy_within(self.decoded..self.decoded + self.pending, 0);
+            self.decoded = 0;
+        }
+
+        while self.pending < amount {
+            let read = transport
+                .read(&mut self.buf[self.decoded + self.pending..])
+                .map_err(|e| TlsError::Io(e.kind()))?;
+            if read == 0 {
+                return Err(TlsError::IoError);
+            }
+            self.pending += read;
+        }
+
+        let slice = &mut self.buf[self.decoded..self.decoded + amount];
+        self.decoded += amount;
+        self.pending -= amount;
+        Ok(slice)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::convert::Infallible;
+
+    use super::*;
+    use crate::{content_types::ContentType, Aes128GcmSha256, TlsCipherSuite};
+
+    struct ChunkRead<'a>(&'a [u8], usize);
+
+    impl embedded_io::Io for ChunkRead<'_> {
+        type Error = Infallible;
+    }
+
+    impl BlockingRead for ChunkRead<'_> {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            let len = usize::min(self.1, buf.len());
+            let len = usize::min(len, self.0.len());
+            buf[..len].copy_from_slice(&self.0[..len]);
+            self.0 = &self.0[len..];
+            Ok(len)
+        }
+    }
+
+    #[test]
+    fn can_read_blocking() {
+        can_read_blocking_case(1, 0);
+        can_read_blocking_case(2, 1);
+        can_read_blocking_case(3, 0);
+        can_read_blocking_case(4, 3);
+        can_read_blocking_case(5, 1);
+        can_read_blocking_case(6, 3);
+        can_read_blocking_case(7, 5);
+        can_read_blocking_case(8, 7);
+        can_read_blocking_case(9, 0);
+        can_read_blocking_case(10, 1);
+        can_read_blocking_case(11, 2);
+        can_read_blocking_case(12, 3);
+        can_read_blocking_case(13, 4);
+        can_read_blocking_case(14, 5);
+        can_read_blocking_case(15, 6);
+        can_read_blocking_case(16, 7);
+    }
+
+    fn can_read_blocking_case(chunk_size: usize, expected_pending: usize) {
+        let mut transport = ChunkRead(
+            &[
+                // Header
+                ContentType::ApplicationData as u8,
+                0x03,
+                0x03,
+                0x00,
+                0x04,
+                // Data
+                0xde,
+                0xad,
+                0xbe,
+                0xef,
+                // Header
+                ContentType::ApplicationData as u8,
+                0x03,
+                0x03,
+                0x00,
+                0x02,
+                // Data
+                0xaa,
+                0xbb,
+            ],
+            chunk_size,
+        );
+
+        let mut buf = [0; 32];
+        let mut reader = RecordReader::<Aes128GcmSha256>::new(&mut buf);
+        let mut key_schedule = KeySchedule::<
+            <Aes128GcmSha256 as TlsCipherSuite>::Hash,
+            <Aes128GcmSha256 as TlsCipherSuite>::KeyLen,
+            <Aes128GcmSha256 as TlsCipherSuite>::IvLen,
+        >::new();
+
+        {
+            if let ServerRecord::ApplicationData(data) = reader
+                .read_blocking(&mut transport, &mut key_schedule)
+                .unwrap()
+            {
+                assert_eq!([0xde, 0xad, 0xbe, 0xef], data.data.as_slice());
+            } else {
+                panic!("Wrong server record");
+            }
+
+            assert_eq!(9, reader.decoded);
+            assert_eq!(expected_pending, reader.pending);
+        }
+
+        {
+            if let ServerRecord::ApplicationData(data) = reader
+                .read_blocking(&mut transport, &mut key_schedule)
+                .unwrap()
+            {
+                assert_eq!([0xaa, 0xbb], data.data.as_slice());
+            } else {
+                panic!("Wrong server record");
+            }
+
+            assert_eq!(16, reader.decoded);
+            assert_eq!(0, reader.pending);
+        }
+    }
+}


### PR DESCRIPTION
This significantly reduces the number of `transport.read()` calls.

The pr includes a `Reminder` type that describes the cursors within the read buffer which were read but are not yet consumed. To do this, the connection `process()` function now uses both at tx and rx buffer, as we need to track if there is a reminder (application data) after the connection is established.