### PR TITLE
Refactor `decrypt_record` to process records immediately without queueing

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -222,16 +222,14 @@ where
         decrypt_record::<CipherSuite>(&mut self.key_schedule, record, |_key_schedule, record| {
             match record {
                 ServerRecord::ApplicationData(data) => {
-                    trace!("Got application data record");
-
                     // SAFETY: Assume `decrypt_record()` to decrypt in-place
                     // We have assertions to ensure this is valid.
                     let slice = data.data.as_slice();
                     let slice_ptr = slice.as_ptr();
                     let offset = unsafe { slice_ptr.offset_from(buf_ptr) };
-                    assert!(offset >= 0);
+                    debug_assert!(offset >= 0);
                     let offset = offset as usize;
-                    assert!(offset + slice.len() <= buf_len);
+                    debug_assert!(offset + slice.len() <= buf_len);
 
                     self.decrypted_offset = offset;
                     self.decrypted_len = slice.len();

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -224,6 +224,7 @@ where
         decrypt_record_in_place::<CipherSuite, _>(
             &mut self.key_schedule,
             record,
+            (),
             |_key_schedule, record| {
                 match record {
                     ServerRecord::ApplicationData(data) => {
@@ -262,7 +263,6 @@ where
                 }
             },
         )
-        .map(|buffer| buffer.unwrap_or(()))
     }
 
     /// Close a connection instance, returning the ownership of the config, random generator and the async I/O provider.

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -221,7 +221,7 @@ where
             .read(&mut self.delegate, &mut self.key_schedule)
             .await?;
 
-        decrypt_record_in_place::<CipherSuite, _>(
+        decrypt_record::<CipherSuite, _>(
             &mut self.key_schedule,
             record,
             (),

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -1,5 +1,3 @@
-use core::ops::ControlFlow;
-
 use crate::alert::*;
 use crate::connection::*;
 use crate::handshake::ServerHandshake;
@@ -221,48 +219,45 @@ where
             .read(&mut self.delegate, &mut self.key_schedule)
             .await?;
 
-        decrypt_record::<CipherSuite, _>(
-            &mut self.key_schedule,
-            record,
-            (),
-            |_key_schedule, record| {
-                match record {
-                    ServerRecord::ApplicationData(data) => {
-                        trace!("Got application data record");
+        decrypt_record::<CipherSuite>(&mut self.key_schedule, record, |_key_schedule, record| {
+            match record {
+                ServerRecord::ApplicationData(data) => {
+                    trace!("Got application data record");
 
-                        // SAFETY: Assume `decrypt_record()` to decrypt in-place
-                        // We have assertions to ensure this is valid.
-                        let slice = data.data.as_slice();
-                        let slice_ptr = slice.as_ptr();
-                        let offset = unsafe { slice_ptr.offset_from(buf_ptr) };
-                        assert!(offset >= 0);
-                        let offset = offset as usize;
-                        assert!(offset + slice.len() <= buf_len);
+                    // SAFETY: Assume `decrypt_record()` to decrypt in-place
+                    // We have assertions to ensure this is valid.
+                    let slice = data.data.as_slice();
+                    let slice_ptr = slice.as_ptr();
+                    let offset = unsafe { slice_ptr.offset_from(buf_ptr) };
+                    assert!(offset >= 0);
+                    let offset = offset as usize;
+                    assert!(offset + slice.len() <= buf_len);
 
-                        self.decrypted_offset = offset;
-                        self.decrypted_len = slice.len();
-                        self.decrypted_consumed = 0;
-                        Ok(ControlFlow::Break(()))
-                    }
-                    ServerRecord::Alert(alert) => {
-                        if let AlertDescription::CloseNotify = alert.description {
-                            self.opened = false;
-                            Err(TlsError::ConnectionClosed)
-                        } else {
-                            Err(TlsError::InternalError)
-                        }
-                    }
-                    ServerRecord::ChangeCipherSpec(_) => Err(TlsError::InternalError),
-                    ServerRecord::Handshake(ServerHandshake::NewSessionTicket(_)) => {
-                        // Ignore
-                        Ok(ControlFlow::Continue(()))
-                    }
-                    _ => {
-                        unimplemented!()
+                    self.decrypted_offset = offset;
+                    self.decrypted_len = slice.len();
+                    self.decrypted_consumed = 0;
+                    Ok(())
+                }
+                ServerRecord::Alert(alert) => {
+                    if let AlertDescription::CloseNotify = alert.description {
+                        self.opened = false;
+                        Err(TlsError::ConnectionClosed)
+                    } else {
+                        Err(TlsError::InternalError)
                     }
                 }
-            },
-        )
+                ServerRecord::ChangeCipherSpec(_) => Err(TlsError::InternalError),
+                ServerRecord::Handshake(ServerHandshake::NewSessionTicket(_)) => {
+                    // Ignore
+                    Ok(())
+                }
+                _ => {
+                    unimplemented!()
+                }
+            }
+        })?;
+
+        Ok(())
     }
 
     /// Close a connection instance, returning the ownership of the config, random generator and the async I/O provider.

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -219,6 +219,7 @@ where
         decrypt_record_in_place::<CipherSuite, _>(
             &mut self.key_schedule,
             record,
+            (),
             |_key_schedule, record| {
                 match record {
                     ServerRecord::ApplicationData(data) => {
@@ -257,7 +258,6 @@ where
                 }
             },
         )
-        .map(|buffer| buffer.unwrap_or(()))
     }
 
     fn close_internal(&mut self) -> Result<(), TlsError> {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,3 +1,5 @@
+use core::ops::ControlFlow;
+
 use crate::alert::*;
 use crate::connection::*;
 use crate::handshake::ServerHandshake;
@@ -11,8 +13,6 @@ use embedded_io::{
     Io,
 };
 use rand_core::{CryptoRng, RngCore};
-
-use heapless::spsc::Queue;
 
 pub use crate::config::*;
 pub use crate::TlsError;
@@ -215,46 +215,49 @@ where
         let record = self
             .record_reader
             .read_blocking(&mut self.delegate, &mut self.key_schedule)?;
-        let mut records = Queue::new();
-        decrypt_record::<CipherSuite>(&mut self.key_schedule, &mut records, record)?;
 
-        while let Some(record) = records.dequeue() {
-            match record {
-                ServerRecord::ApplicationData(data) => {
-                    // SAFETY: Assume `decrypt_record()` to decrypt in-place
-                    // We have assertions to ensure this is valid.
-                    let slice = data.data.as_slice();
-                    let slice_ptr = slice.as_ptr();
-                    let offset = unsafe { slice_ptr.offset_from(buf_ptr) };
-                    debug_assert!(offset >= 0);
-                    let offset = offset as usize;
-                    debug_assert!(offset + slice.len() <= buf_len);
+        decrypt_record_in_place::<CipherSuite, _>(
+            &mut self.key_schedule,
+            record,
+            |_key_schedule, record| {
+                match record {
+                    ServerRecord::ApplicationData(data) => {
+                        trace!("Got application data record");
 
-                    self.decrypted_offset = offset;
-                    self.decrypted_len = slice.len();
-                    self.decrypted_consumed = 0;
-                    return Ok(());
-                }
-                ServerRecord::Alert(alert) => {
-                    if let AlertDescription::CloseNotify = alert.description {
-                        self.opened = false;
-                        Err(TlsError::ConnectionClosed)
-                    } else {
-                        Err(TlsError::InternalError)
+                        // SAFETY: Assume `decrypt_record()` to decrypt in-place
+                        // We have assertions to ensure this is valid.
+                        let slice = data.data.as_slice();
+                        let slice_ptr = slice.as_ptr();
+                        let offset = unsafe { slice_ptr.offset_from(buf_ptr) };
+                        assert!(offset >= 0);
+                        let offset = offset as usize;
+                        assert!(offset + slice.len() <= buf_len);
+
+                        self.decrypted_offset = offset;
+                        self.decrypted_len = slice.len();
+                        self.decrypted_consumed = 0;
+                        Ok(ControlFlow::Break(()))
+                    }
+                    ServerRecord::Alert(alert) => {
+                        if let AlertDescription::CloseNotify = alert.description {
+                            self.opened = false;
+                            Err(TlsError::ConnectionClosed)
+                        } else {
+                            Err(TlsError::InternalError)
+                        }
+                    }
+                    ServerRecord::ChangeCipherSpec(_) => Err(TlsError::InternalError),
+                    ServerRecord::Handshake(ServerHandshake::NewSessionTicket(_)) => {
+                        // Ignore
+                        Ok(ControlFlow::Continue(()))
+                    }
+                    _ => {
+                        unimplemented!()
                     }
                 }
-                ServerRecord::ChangeCipherSpec(_) => Err(TlsError::InternalError),
-                ServerRecord::Handshake(ServerHandshake::NewSessionTicket(_)) => {
-                    // Ignore
-                    Ok(())
-                }
-                _ => {
-                    unimplemented!()
-                }
-            }?;
-        }
-
-        Ok(())
+            },
+        )
+        .map(|buffer| buffer.unwrap_or(()))
     }
 
     fn close_internal(&mut self) -> Result<(), TlsError> {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -216,7 +216,7 @@ where
             .record_reader
             .read_blocking(&mut self.delegate, &mut self.key_schedule)?;
 
-        decrypt_record_in_place::<CipherSuite, _>(
+        decrypt_record::<CipherSuite, _>(
             &mut self.key_schedule,
             record,
             (),

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -217,16 +217,14 @@ where
         decrypt_record::<CipherSuite>(&mut self.key_schedule, record, |_key_schedule, record| {
             match record {
                 ServerRecord::ApplicationData(data) => {
-                    trace!("Got application data record");
-
                     // SAFETY: Assume `decrypt_record()` to decrypt in-place
                     // We have assertions to ensure this is valid.
                     let slice = data.data.as_slice();
                     let slice_ptr = slice.as_ptr();
                     let offset = unsafe { slice_ptr.offset_from(buf_ptr) };
-                    assert!(offset >= 0);
+                    debug_assert!(offset >= 0);
                     let offset = offset as usize;
-                    assert!(offset + slice.len() <= buf_len);
+                    debug_assert!(offset + slice.len() <= buf_len);
 
                     self.decrypted_offset = offset;
                     self.decrypted_len = slice.len();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -41,7 +41,7 @@ use crate::parse_buffer::ParseBuffer;
 use aes_gcm::aead::{AeadCore, AeadInPlace, KeyInit};
 use digest::OutputSizeUser;
 
-pub(crate) fn decrypt_record_in_place<'m, CipherSuite, R>(
+pub(crate) fn decrypt_record<'m, CipherSuite, R>(
     key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
     record: ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
     default: R,
@@ -551,7 +551,7 @@ where
     CipherSuite: TlsCipherSuite + 'static,
     Verifier: TlsVerifier<CipherSuite>,
 {
-    decrypt_record_in_place::<CipherSuite, _>(
+    decrypt_record::<CipherSuite, _>(
         key_schedule,
         record,
         State::ServerVerify,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -574,8 +574,6 @@ where
                             .replace(key_schedule.transcript_hash().clone());
                         State::ClientFinished
                     };
-
-                    return Ok(());
                 }
                 _ => return Err(TlsError::InvalidHandshake),
             },

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -40,22 +40,6 @@ use crate::content_types::ContentType;
 use crate::parse_buffer::ParseBuffer;
 use aes_gcm::aead::{AeadCore, AeadInPlace, KeyInit};
 use digest::OutputSizeUser;
-use heapless::spsc::Queue;
-
-pub(crate) fn decrypt_record<'m, CipherSuite>(
-    key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
-    records: &mut Queue<ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>, 8>,
-    record: ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
-) -> Result<(), TlsError>
-where
-    CipherSuite: TlsCipherSuite + 'static,
-{
-    decrypt_record_in_place::<CipherSuite, _>(key_schedule, record, (), |_key_schedule, record| {
-        records.enqueue(record).map_err(|_| TlsError::EncodeError)?;
-
-        Ok(ControlFlow::Continue(()))
-    })
-}
 
 pub(crate) fn decrypt_record_in_place<'m, CipherSuite, R>(
     key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,


### PR DESCRIPTION
I don't exactly have a goal with this one, except that maintaining a queue for 8 records looked somewhat arbitrary and we can pass the processing code to `decrypt_record` directly.

I'm unsure about the last commit - I personally prefer the increased control using ControlFlow, but the result was much more complex than ideal.