### PR TITLE
Fix or suppress clippy warnings

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -269,16 +269,15 @@ where
             self.opened,
         );
 
-        let mut key_schedule = &mut self.key_schedule;
         let (_, len) =
-            encode_record::<CipherSuite>(self.record_write_buf, &mut key_schedule, &record)?;
+            encode_record::<CipherSuite>(self.record_write_buf, &mut self.key_schedule, &record)?;
 
         self.delegate
             .write_all(&self.record_write_buf[..len])
             .await
             .map_err(|e| TlsError::Io(e.kind()))?;
 
-        key_schedule.increment_write_counter();
+        self.key_schedule.increment_write_counter();
 
         Ok(())
     }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -209,7 +209,7 @@ where
         }
     }
 
-    fn read_application_data<'m>(&'m mut self) -> Result<CryptoBuffer<'m>, TlsError> {
+    fn read_application_data(&mut self) -> Result<CryptoBuffer, TlsError> {
         let buf_ptr = self.record_reader.buf.as_ptr();
         let buf_len = self.record_reader.buf.len();
         let record = self

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -226,7 +226,7 @@ where
     Ok((next_hash, len))
 }
 
-pub fn encode_application_data_record_in_place<'m, CipherSuite>(
+pub fn encode_application_data_record_in_place<CipherSuite>(
     tx_buf: &mut [u8],
     data_len: usize,
     key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
@@ -250,7 +250,7 @@ where
     verifier: Verifier,
 }
 
-impl<'a, CipherSuite, Verifier> Handshake<CipherSuite, Verifier>
+impl<CipherSuite, Verifier> Handshake<CipherSuite, Verifier>
 where
     CipherSuite: TlsCipherSuite + 'static,
     Verifier: TlsVerifier<CipherSuite>,
@@ -278,6 +278,7 @@ pub enum State {
 
 impl<'a> State {
     #[cfg(feature = "async")]
+    #[allow(clippy::too_many_arguments)]
     pub async fn process<Transport, CipherSuite, RNG, Verifier>(
         self,
         transport: &mut Transport,
@@ -390,6 +391,7 @@ impl<'a> State {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn process_blocking<Transport, CipherSuite, RNG, Verifier>(
         self,
         transport: &mut Transport,

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -224,7 +224,7 @@ impl ClientExtension<'_> {
                     buf.extend_from_slice(&(identity.len() as u16).to_be_bytes())
                         .map_err(|_| TlsError::EncodeError)?;
 
-                    buf.extend_from_slice(&identity)
+                    buf.extend_from_slice(identity)
                         .map_err(|_| TlsError::EncodeError)?;
 
                     // NOTE: No support for ticket age, set to 0 as recommended by RFC

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -72,6 +72,7 @@ impl HandshakeType {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum ClientHandshake<'config, 'a, CipherSuite>
 where
     CipherSuite: TlsCipherSuite,
@@ -172,9 +173,9 @@ impl<'a, N: ArrayLength<u8>> ServerHandshake<'a, N> {
                 match handshake_type {
                     HandshakeType::ServerHello => {
                         // info!("hash [{:x?}]", &header);
-                        digest.update(&header);
+                        digest.update(header);
                         Ok(ServerHandshake::ServerHello(ServerHello::read(
-                            &rx_buf
+                            rx_buf
                                 .get(4..length + 4)
                                 .ok_or(TlsError::InvalidHandshake)?,
                             digest,

--- a/src/handshake/server_hello.rs
+++ b/src/handshake/server_hello.rs
@@ -23,7 +23,7 @@ pub struct ServerHello<'a> {
 impl<'a> ServerHello<'a> {
     pub fn read<D: Digest>(buf: &'a [u8], digest: &mut D) -> Result<ServerHello<'a>, TlsError> {
         //trace!("server hello hash [{:x?}]", &buf[..]);
-        digest.update(&buf);
+        digest.update(buf);
         Self::parse(&mut ParseBuffer::new(buf))
     }
 

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -222,6 +222,7 @@ where
     pub fn initialize_early_secret(&mut self, psk: Option<&[u8]>) -> Result<(), TlsError> {
         let (secret, hkdf) = Hkdf::<D, SimpleHmac<D>>::extract(
             Some(self.secret.as_ref()),
+            #[allow(clippy::or_fun_call)]
             psk.unwrap_or(Self::zero().as_slice()),
         );
         self.hkdf.replace(hkdf);
@@ -315,7 +316,7 @@ where
 
         let label_len = 6 + label.len() as u8;
         hkdf_label
-            .extend_from_slice(&(label_len as u8).to_be_bytes())
+            .extend_from_slice(&label_len.to_be_bytes())
             .map_err(|_| TlsError::InternalError)?;
         hkdf_label
             .extend_from_slice(b"tls13 ")
@@ -338,7 +339,7 @@ where
                     .map_err(|_| TlsError::InternalError)?;
             }
             ContextType::EmptyHash => {
-                let context = D::new().chain_update(&[]).finalize();
+                let context = D::new().chain_update([]).finalize();
                 hkdf_label
                     .extend_from_slice(&(context.len() as u8).to_be_bytes())
                     .map_err(|_| TlsError::InternalError)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ pub enum TlsError {
 impl embedded_io::Error for TlsError {
     fn kind(&self) -> embedded_io::ErrorKind {
         match self {
-            Self::Io(k) => k.clone(),
+            Self::Io(k) => *k,
             _ => embedded_io::ErrorKind::Other,
         }
     }

--- a/src/record.rs
+++ b/src/record.rs
@@ -15,6 +15,7 @@ use sha2::Digest;
 
 pub type Encrypted = bool;
 
+#[allow(clippy::large_enum_variant)]
 pub enum ClientRecord<'config, 'a, CipherSuite>
 where
     // N: ArrayLength<u8>,
@@ -109,7 +110,7 @@ where
             ClientRecord::ChangeCipherSpec(spec, true) => {
                 let mut wrapped = buf.forward();
 
-                let _ = spec.encode(&mut wrapped)?;
+                spec.encode(&mut wrapped)?;
                 wrapped
                     .push(ContentType::ChangeCipherSpec as u8)
                     .map_err(|_| TlsError::EncodeError)?;
@@ -124,7 +125,7 @@ where
             ClientRecord::Alert(alert, true) => {
                 let mut wrapped = buf.forward();
 
-                let _ = alert.encode(&mut wrapped)?;
+                alert.encode(&mut wrapped)?;
                 wrapped
                     .push(ContentType::Alert as u8)
                     .map_err(|_| TlsError::EncodeError)?;
@@ -207,6 +208,7 @@ pub(crate) fn encode_application_data_in_place<
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[allow(clippy::large_enum_variant)]
 pub enum ServerRecord<'a, N: ArrayLength<u8>> {
     Handshake(ServerHandshake<'a, N>),
     ChangeCipherSpec(ChangeCipherSpec),


### PR DESCRIPTION
This PR cleans up clippy warnings the lazy way. Still, I think cleaning up a few unnecessary borrows and lifetimes is nice, even if it's not a huge impact.