### PR TITLE
Implement non-copying read functions

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -255,9 +255,9 @@ where
                     let slice = data.data.as_slice();
                     let slice_ptr = slice.as_ptr();
                     let offset = unsafe { slice_ptr.offset_from(buf_ptr) };
-                    assert!(offset >= 0);
+                    debug_assert!(offset >= 0);
                     let offset = offset as usize;
-                    assert!(offset + slice.len() <= buf_len);
+                    debug_assert!(offset + slice.len() <= buf_len);
 
                     self.decrypted_offset = offset;
                     self.decrypted_len = slice.len();

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -214,7 +214,30 @@ where
         }
     }
 
-    async fn read_application_data<'m>(&'m mut self) -> Result<CryptoBuffer<'m>, TlsError> {
+    /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
+    pub async fn read_buffered(&mut self) -> Result<&[u8], TlsError> {
+        if self.opened {
+            let record_data = if self.decrypted_consumed < self.decrypted_len {
+                // The current record is not completely consumed
+                let buffer = CryptoBuffer::wrap(
+                    &mut self.record_reader.buf
+                        [self.decrypted_offset..self.decrypted_offset + self.decrypted_len],
+                );
+
+                self.decrypted_consumed = self.decrypted_len;
+                buffer
+            } else {
+                // The current record is completely consumed, read the next...
+                self.read_application_data().await?
+            };
+
+            Ok(record_data.into_slice())
+        } else {
+            Err(TlsError::MissingHandshake)
+        }
+    }
+
+    async fn read_application_data(&mut self) -> Result<CryptoBuffer, TlsError> {
         let buf_ptr = self.record_reader.buf.as_ptr();
         let buf_len = self.record_reader.buf.len();
         let record = self

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -181,26 +181,20 @@ where
     /// Read and decrypt data filling the provided slice.
     pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize, TlsError> {
         if self.opened {
-            if buf.is_empty() {
-                return Ok(0);
+            while self.need_to_read() {
+                self.read_application_data().await?;
             }
-            let mut remaining = buf.len();
-            while remaining == buf.len() {
-                if self.need_to_read() {
-                    self.read_application_data().await?;
-                }
 
-                let start = self.decrypted_offset + self.decrypted_consumed;
-                let end = self.decrypted_offset + self.decrypted_len;
-                let unread = &self.record_reader.buf[start..end];
+            let start = self.decrypted_offset + self.decrypted_consumed;
+            let end = self.decrypted_offset + self.decrypted_len;
+            let unread = &self.record_reader.buf[start..end];
 
-                let to_copy = core::cmp::min(unread.len(), buf.len());
-                trace!("Got {} bytes to copy", to_copy);
-                buf[..to_copy].copy_from_slice(&unread[..to_copy]);
-                self.decrypted_consumed += to_copy;
-                remaining -= to_copy;
-            }
-            Ok(buf.len() - remaining)
+            let to_copy = core::cmp::min(unread.len(), buf.len());
+            trace!("Got {} bytes to copy", to_copy);
+            buf[..to_copy].copy_from_slice(&unread[..to_copy]);
+            self.decrypted_consumed += to_copy;
+
+            Ok(to_copy)
         } else {
             Err(TlsError::MissingHandshake)
         }

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -250,8 +250,6 @@ where
         while let Some(record) = records.dequeue() {
             match record {
                 ServerRecord::ApplicationData(data) => {
-                    trace!("Got application data record");
-
                     // SAFETY: Assume `decrypt_record()` to decrypt in-place
                     // We have assertions to ensure this is valid.
                     let slice = data.data.as_slice();

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -192,7 +192,7 @@ where
     pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize, TlsError> {
         let mut buffer = self.read_buffered().await?;
 
-        let to_copy = buffer.take(buf.len());
+        let to_copy = buffer.pop(buf.len());
 
         trace!("Got {} bytes to copy", to_copy.len());
         buf[..to_copy.len()].copy_from_slice(to_copy);

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -2,6 +2,7 @@ use crate::alert::*;
 use crate::connection::*;
 use crate::handshake::ServerHandshake;
 use crate::key_schedule::KeySchedule;
+use crate::read_buffer::ReadBuffer;
 use crate::record::{ClientRecord, ServerRecord};
 use crate::record_reader::RecordReader;
 use crate::TlsError;
@@ -178,42 +179,35 @@ where
         Ok(())
     }
 
+    fn create_read_buffer(&mut self) -> ReadBuffer {
+        let offset = self.decrypted_offset + self.decrypted_consumed;
+        let end = self.decrypted_offset + self.decrypted_len;
+        ReadBuffer::new(
+            &mut self.record_reader.buf[offset..end],
+            &mut self.decrypted_consumed,
+        )
+    }
+
     /// Read and decrypt data filling the provided slice.
     pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize, TlsError> {
-        if self.opened {
-            while self.need_to_read() {
-                self.read_application_data().await?;
-            }
+        let mut buffer = self.read_buffered().await?;
 
-            let start = self.decrypted_offset + self.decrypted_consumed;
-            let end = self.decrypted_offset + self.decrypted_len;
-            let unread = &self.record_reader.buf[start..end];
+        let to_copy = buffer.take(buf.len());
 
-            let to_copy = core::cmp::min(unread.len(), buf.len());
-            trace!("Got {} bytes to copy", to_copy);
-            buf[..to_copy].copy_from_slice(&unread[..to_copy]);
-            self.decrypted_consumed += to_copy;
+        trace!("Got {} bytes to copy", to_copy.len());
+        buf[..to_copy.len()].copy_from_slice(to_copy);
 
-            Ok(to_copy)
-        } else {
-            Err(TlsError::MissingHandshake)
-        }
+        Ok(to_copy.len())
     }
 
     /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
-    pub async fn read_buffered(&mut self) -> Result<&[u8], TlsError> {
+    pub async fn read_buffered(&mut self) -> Result<ReadBuffer, TlsError> {
         if self.opened {
             while self.need_to_read() {
                 self.read_application_data().await?;
             }
 
-            let start = self.decrypted_offset + self.decrypted_consumed;
-            let end = self.decrypted_offset + self.decrypted_len;
-            let buffer = &self.record_reader.buf[start..end];
-
-            self.decrypted_consumed = self.decrypted_len;
-
-            Ok(buffer)
+            Ok(self.create_read_buffer())
         } else {
             Err(TlsError::MissingHandshake)
         }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -250,9 +250,9 @@ where
                     let slice = data.data.as_slice();
                     let slice_ptr = slice.as_ptr();
                     let offset = unsafe { slice_ptr.offset_from(buf_ptr) };
-                    assert!(offset >= 0);
+                    debug_assert!(offset >= 0);
                     let offset = offset as usize;
-                    assert!(offset + slice.len() <= buf_len);
+                    debug_assert!(offset + slice.len() <= buf_len);
 
                     self.decrypted_offset = offset;
                     self.decrypted_len = slice.len();

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -188,7 +188,7 @@ where
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, TlsError> {
         let mut buffer = self.read_buffered()?;
 
-        let to_copy = buffer.take(buf.len());
+        let to_copy = buffer.pop(buf.len());
 
         trace!("Got {} bytes to copy", to_copy.len());
         buf[..to_copy.len()].copy_from_slice(to_copy);

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,5 +1,4 @@
 use crate::alert::*;
-use crate::buffer::CryptoBuffer;
 use crate::connection::*;
 use crate::handshake::ServerHandshake;
 use crate::key_schedule::KeySchedule;
@@ -182,28 +181,22 @@ where
                 return Ok(0);
             }
             let mut remaining = buf.len();
-            let mut consumed = self.decrypted_consumed;
             while remaining == buf.len() {
-                let record_data = if consumed < self.decrypted_len {
-                    // The current record is not completely consumed
-                    CryptoBuffer::wrap(
-                        &mut self.record_reader.buf
-                            [self.decrypted_offset..self.decrypted_offset + self.decrypted_len],
-                    )
-                } else {
-                    // The current record is completely consumed, read the next...
-                    consumed = 0;
-                    self.read_application_data()?
-                };
+                // Read if we have to
+                if self.decrypted_consumed >= self.decrypted_len {
+                    self.read_application_data()?;
+                }
 
-                let unread = &record_data.as_slice()[consumed..];
+                let start = self.decrypted_offset + self.decrypted_consumed;
+                let end = self.decrypted_offset + self.decrypted_len;
+                let unread = &self.record_reader.buf[start..end];
+
                 let to_copy = core::cmp::min(unread.len(), buf.len());
                 trace!("Got {} bytes to copy", to_copy);
                 buf[..to_copy].copy_from_slice(&unread[..to_copy]);
-                consumed += to_copy;
+                self.decrypted_consumed += to_copy;
                 remaining -= to_copy;
             }
-            self.decrypted_consumed = consumed;
             Ok(buf.len() - remaining)
         } else {
             Err(TlsError::MissingHandshake)
@@ -213,27 +206,23 @@ where
     /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
     pub fn read_buffered(&mut self) -> Result<&[u8], TlsError> {
         if self.opened {
-            let record_data = if self.decrypted_consumed < self.decrypted_len {
-                // The current record is not completely consumed
-                let buffer = CryptoBuffer::wrap(
-                    &mut self.record_reader.buf
-                        [self.decrypted_offset..self.decrypted_offset + self.decrypted_len],
-                );
+            if self.decrypted_consumed >= self.decrypted_len {
+                self.read_application_data()?;
+            }
 
-                self.decrypted_consumed = self.decrypted_len;
-                buffer
-            } else {
-                // The current record is completely consumed, read the next...
-                self.read_application_data()?
-            };
+            let start = self.decrypted_offset + self.decrypted_consumed;
+            let end = self.decrypted_offset + self.decrypted_len;
+            let buffer = &self.record_reader.buf[start..end];
 
-            Ok(record_data.into_slice())
+            self.decrypted_consumed = self.decrypted_len;
+
+            Ok(buffer)
         } else {
             Err(TlsError::MissingHandshake)
         }
     }
 
-    fn read_application_data(&mut self) -> Result<CryptoBuffer, TlsError> {
+    fn read_application_data(&mut self) -> Result<(), TlsError> {
         let buf_ptr = self.record_reader.buf.as_ptr();
         let buf_len = self.record_reader.buf.len();
         let record = self
@@ -257,7 +246,7 @@ where
                     self.decrypted_offset = offset;
                     self.decrypted_len = slice.len();
                     self.decrypted_consumed = 0;
-                    return Ok(data.data);
+                    return Ok(());
                 }
                 ServerRecord::Alert(alert) => {
                     if let AlertDescription::CloseNotify = alert.description {
@@ -278,7 +267,7 @@ where
             }?;
         }
 
-        Ok(CryptoBuffer::empty())
+        Ok(())
     }
 
     fn close_internal(&mut self) -> Result<(), TlsError> {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -182,8 +182,7 @@ where
             }
             let mut remaining = buf.len();
             while remaining == buf.len() {
-                // Read if we have to
-                if self.decrypted_consumed >= self.decrypted_len {
+                if self.need_to_read() {
                     self.read_application_data()?;
                 }
 
@@ -206,7 +205,7 @@ where
     /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
     pub fn read_buffered(&mut self) -> Result<&[u8], TlsError> {
         if self.opened {
-            if self.decrypted_consumed >= self.decrypted_len {
+            while self.need_to_read() {
                 self.read_application_data()?;
             }
 
@@ -294,6 +293,10 @@ where
             Ok(()) => Ok(self.delegate),
             Err(e) => Err((self.delegate, e)),
         }
+    }
+
+    fn need_to_read(&self) -> bool {
+        self.decrypted_consumed >= self.decrypted_len
     }
 }
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -245,8 +245,6 @@ where
         while let Some(record) = records.dequeue() {
             match record {
                 ServerRecord::ApplicationData(data) => {
-                    trace!("Got application data record");
-
                     // SAFETY: Assume `decrypt_record()` to decrypt in-place
                     // We have assertions to ensure this is valid.
                     let slice = data.data.as_slice();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -73,6 +73,10 @@ impl<'b> CryptoBuffer<'b> {
         &self.buf[self.offset..self.offset + self.len]
     }
 
+    pub fn into_slice(self) -> &'b [u8] {
+        &self.buf[self.offset..self.offset + self.len]
+    }
+
     fn extend_internal(&mut self, other: &[u8]) -> Result<(), TlsError> {
         let start = self.offset + self.len;
         if self.capacity - start < other.len() {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -73,10 +73,6 @@ impl<'b> CryptoBuffer<'b> {
         &self.buf[self.offset..self.offset + self.len]
     }
 
-    pub fn into_slice(self) -> &'b [u8] {
-        &self.buf[self.offset..self.offset + self.len]
-    }
-
     fn extend_internal(&mut self, other: &[u8]) -> Result<(), TlsError> {
         let start = self.offset + self.len;
         if self.capacity - start < other.len() {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -80,6 +80,8 @@ where
         let content_type =
             ContentType::of(*app_data.as_slice().last().unwrap()).ok_or(TlsError::InvalidRecord)?;
 
+        trace!("Decrypting content type = {:?}", content_type);
+
         match content_type {
             ContentType::Handshake => {
                 // Decode potentially coaleced handshake messages
@@ -124,7 +126,7 @@ where
         //debug!("decrypted {:?} --> {:x?}", content_type, data);
         key_schedule.increment_read_counter();
     } else {
-        //info!("Not encapsulated in app data");
+        debug!("Not decrypting: Not encapsulated in app data");
         records.enqueue(record).map_err(|_| TlsError::EncodeError)?
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ mod key_schedule;
 mod max_fragment_length;
 mod named_groups;
 mod parse_buffer;
+pub mod read_buffer;
 mod record;
 mod record_reader;
 mod signature_schemes;

--- a/src/read_buffer.rs
+++ b/src/read_buffer.rs
@@ -1,0 +1,123 @@
+/// A reference to consume bytes from the internal buffer.
+#[must_use]
+pub struct ReadBuffer<'a> {
+    data: &'a [u8],
+    consumed: usize,
+    used: bool,
+
+    decrypted_consumed: &'a mut usize,
+}
+
+impl<'a> ReadBuffer<'a> {
+    #[inline]
+    pub(crate) fn new(buffer: &'a [u8], decrypted_consumed: &'a mut usize) -> Self {
+        Self {
+            data: buffer,
+            consumed: 0,
+            used: false,
+            decrypted_consumed,
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.data.len() - self.consumed
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Consumes and returns a slice of at most `count` bytes.
+    #[inline]
+    pub fn take(&mut self, count: usize) -> &[u8] {
+        let count = self.len().min(count);
+        let start = self.consumed;
+        self.consumed += count;
+        self.used = true;
+
+        &self.data[start..start + count]
+    }
+
+    /// Consumes and returns the internal buffer.
+    #[inline]
+    pub fn take_all(&mut self) -> &[u8] {
+        self.take(self.len())
+    }
+
+    /// Drops the reference and restores internal buffer.
+    #[inline]
+    pub fn revert(self) {
+        core::mem::forget(self);
+    }
+}
+
+impl Drop for ReadBuffer<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        *self.decrypted_consumed = if self.used {
+            self.consumed
+        } else {
+            // Consume all if dropped unused
+            self.data.len()
+        };
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn dropping_unused_buffer_consumes_all() {
+        let mut consumed = 0;
+        let buffer = [0, 1, 2, 3];
+
+        _ = ReadBuffer::new(&buffer, &mut consumed);
+
+        assert_eq!(consumed, 4);
+    }
+
+    #[test]
+    fn take_moves_internal_cursor() {
+        let mut consumed = 0;
+
+        let mut buffer = ReadBuffer::new(&[0, 1, 2, 3], &mut consumed);
+
+        assert_eq!(buffer.take(1), &[0]);
+        assert_eq!(buffer.take(1), &[1]);
+        assert_eq!(buffer.take(1), &[2]);
+    }
+
+    #[test]
+    fn dropping_consumes_as_many_bytes_as_used() {
+        let mut consumed = 0;
+
+        let mut buffer = ReadBuffer::new(&[0, 1, 2, 3], &mut consumed);
+
+        assert_eq!(buffer.take(1), &[0]);
+        assert_eq!(buffer.take(1), &[1]);
+        assert_eq!(buffer.take(1), &[2]);
+
+        core::mem::drop(buffer);
+
+        assert_eq!(consumed, 3);
+    }
+
+    #[test]
+    fn take_returns_fewer_bytes_if_requested_more_than_what_it_has() {
+        let mut consumed = 0;
+
+        let mut buffer = ReadBuffer::new(&[0, 1, 2, 3], &mut consumed);
+
+        assert_eq!(buffer.take(1), &[0]);
+        assert_eq!(buffer.take(1), &[1]);
+        assert_eq!(buffer.take(4), &[2, 3]);
+        assert_eq!(buffer.take(1), &[]);
+
+        core::mem::drop(buffer);
+
+        assert_eq!(consumed, 4);
+    }
+}

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -137,10 +137,6 @@ async fn test_ping_nocopy() {
     write_fut.await.expect("error writing data");
     tls.flush().await.expect("error flushing data");
 
-    // TODO: solve this empty read
-    let buf = tls.read_buffered().await.expect("error reading data");
-    log::info!("Read bytes: {:?}", buf);
-
     let buf = tls.read_buffered().await.expect("error reading data");
     assert_eq!(b"ping", buf);
     log::info!("Read bytes: {:?}", buf);
@@ -226,10 +222,6 @@ fn test_blocking_ping_nocopy() {
 
     tls.write(b"ping").expect("error writing data");
     tls.flush().expect("error flushing data");
-
-    // TODO: solve this empty read
-    let buf = tls.read_buffered().expect("error reading data");
-    log::info!("Read bytes: {:?}", buf);
 
     let buf = tls.read_buffered().expect("error reading data");
     assert_eq!(b"ping", buf);

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -137,9 +137,12 @@ async fn test_ping_nocopy() {
     write_fut.await.expect("error writing data");
     tls.flush().await.expect("error flushing data");
 
-    let buf = tls.read_buffered().await.expect("error reading data");
-    assert_eq!(b"ping", buf);
-    log::info!("Read bytes: {:?}", buf);
+    let mut buf = tls.read_buffered().await.expect("error reading data");
+    let read_bytes = buf.take_all();
+    assert_eq!(b"ping", read_bytes);
+    log::info!("Read bytes: {:?}", read_bytes);
+
+    core::mem::drop(buf);
 
     tls.close()
         .await
@@ -223,9 +226,12 @@ fn test_blocking_ping_nocopy() {
     tls.write(b"ping").expect("error writing data");
     tls.flush().expect("error flushing data");
 
-    let buf = tls.read_buffered().expect("error reading data");
-    assert_eq!(b"ping", buf);
-    log::info!("Read bytes: {:?}", buf);
+    let mut buf = tls.read_buffered().expect("error reading data");
+    let read_bytes = buf.take_all();
+    assert_eq!(b"ping", read_bytes);
+    log::info!("Read bytes: {:?}", read_bytes);
+
+    core::mem::drop(buf);
 
     tls.close()
         .map_err(|(_, e)| e)

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -138,7 +138,7 @@ async fn test_ping_nocopy() {
     tls.flush().await.expect("error flushing data");
 
     let mut buf = tls.read_buffered().await.expect("error reading data");
-    let read_bytes = buf.take_all();
+    let read_bytes = buf.pop_all();
     assert_eq!(b"ping", read_bytes);
     log::info!("Read bytes: {:?}", read_bytes);
 
@@ -227,7 +227,7 @@ fn test_blocking_ping_nocopy() {
     tls.flush().expect("error flushing data");
 
     let mut buf = tls.read_buffered().expect("error reading data");
-    let read_bytes = buf.take_all();
+    let read_bytes = buf.pop_all();
     assert_eq!(b"ping", read_bytes);
     log::info!("Read bytes: {:?}", read_bytes);
 


### PR DESCRIPTION
The idea behind this PR is that data is already decrypted in an internal buffer, so we might as well return a reference to it. I've also taken the liberty to refactor `read()` to a similar "read while empty then return" structure that I think cleaned it up pretty well.