### PR TITLE
Remove outdated comment

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -175,9 +175,7 @@ where
         Ok(())
     }
 
-    /// Read and decrypt data filling the provided slice. The slice must be able to
-    /// keep the expected amount of data that can be received in one record to avoid
-    /// losing data.
+    /// Read and decrypt data filling the provided slice.
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, TlsError> {
         if self.opened {
             let mut remaining = buf.len();


### PR DESCRIPTION
Follow-up for #76 - I don't think passing in a small buffer causes data loss, as the code seems to track partially read records.

The comment is also missing from the async counterpart.