### PR TITLE
Clean up

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -1,4 +1,5 @@
 use crate::alert::*;
+use crate::common::decrypted_buffer_info::DecryptedBufferInfo;
 use crate::connection::*;
 use crate::handshake::ServerHandshake;
 use crate::key_schedule::KeySchedule;
@@ -32,9 +33,7 @@ where
     record_reader: RecordReader<'a, CipherSuite>,
     record_write_buf: &'a mut [u8],
     write_pos: usize,
-    decrypted_offset: usize,
-    decrypted_len: usize,
-    decrypted_consumed: usize,
+    decrypted: DecryptedBufferInfo,
 }
 
 impl<'a, Socket, CipherSuite> TlsConnection<'a, Socket, CipherSuite>
@@ -69,9 +68,7 @@ where
             record_reader: RecordReader::new(record_read_buf),
             record_write_buf,
             write_pos: 0,
-            decrypted_offset: 0,
-            decrypted_len: 0,
-            decrypted_consumed: 0,
+            decrypted: DecryptedBufferInfo::default(),
         }
     }
 
@@ -178,12 +175,7 @@ where
     }
 
     fn create_read_buffer(&mut self) -> ReadBuffer {
-        let offset = self.decrypted_offset + self.decrypted_consumed;
-        let end = self.decrypted_offset + self.decrypted_len;
-        ReadBuffer::new(
-            &mut self.record_reader.buf[offset..end],
-            &mut self.decrypted_consumed,
-        )
+        self.decrypted.create_read_buffer(self.record_reader.buf)
     }
 
     /// Read and decrypt data filling the provided slice.
@@ -201,7 +193,7 @@ where
     /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
     pub async fn read_buffered(&mut self) -> Result<ReadBuffer, TlsError> {
         if self.opened {
-            while self.need_to_read() {
+            while self.decrypted.is_empty() {
                 self.read_application_data().await?;
             }
 
@@ -231,9 +223,9 @@ where
                     let offset = offset as usize;
                     debug_assert!(offset + slice.len() <= buf_len);
 
-                    self.decrypted_offset = offset;
-                    self.decrypted_len = slice.len();
-                    self.decrypted_consumed = 0;
+                    self.decrypted.offset = offset;
+                    self.decrypted.len = slice.len();
+                    self.decrypted.consumed = 0;
                     Ok(())
                 }
                 ServerRecord::Alert(alert) => {
@@ -284,10 +276,6 @@ where
             Ok(()) => Ok(self.delegate),
             Err(e) => Err((self.delegate, e)),
         }
-    }
-
-    fn need_to_read(&self) -> bool {
-        self.decrypted_consumed >= self.decrypted_len
     }
 }
 

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -29,7 +29,7 @@ where
 {
     delegate: Socket,
     opened: bool,
-    key_schedule: KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    key_schedule: KeySchedule<CipherSuite>,
     record_reader: RecordReader<'a, CipherSuite>,
     record_write_buf: &'a mut [u8],
     write_pos: usize,

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -1,10 +1,10 @@
 use crate::alert::*;
 use crate::common::decrypted_buffer_info::DecryptedBufferInfo;
+use crate::common::decrypted_read_handler::DecryptedReadHandler;
 use crate::connection::*;
-use crate::handshake::ServerHandshake;
 use crate::key_schedule::KeySchedule;
 use crate::read_buffer::ReadBuffer;
-use crate::record::{ClientRecord, ServerRecord};
+use crate::record::ClientRecord;
 use crate::record_reader::RecordReader;
 use crate::TlsError;
 use embedded_io::Error as _;
@@ -211,40 +211,14 @@ where
             .read(&mut self.delegate, &mut self.key_schedule)
             .await?;
 
+        let mut handler = DecryptedReadHandler {
+            source_buffer_ptr: buf_ptr,
+            source_buffer_len: buf_len,
+            buffer_info: &mut self.decrypted,
+            is_open: &mut self.opened,
+        };
         decrypt_record::<CipherSuite>(&mut self.key_schedule, record, |_key_schedule, record| {
-            match record {
-                ServerRecord::ApplicationData(data) => {
-                    // SAFETY: Assume `decrypt_record()` to decrypt in-place
-                    // We have assertions to ensure this is valid.
-                    let slice = data.data.as_slice();
-                    let slice_ptr = slice.as_ptr();
-                    let offset = unsafe { slice_ptr.offset_from(buf_ptr) };
-                    debug_assert!(offset >= 0);
-                    let offset = offset as usize;
-                    debug_assert!(offset + slice.len() <= buf_len);
-
-                    self.decrypted.offset = offset;
-                    self.decrypted.len = slice.len();
-                    self.decrypted.consumed = 0;
-                    Ok(())
-                }
-                ServerRecord::Alert(alert) => {
-                    if let AlertDescription::CloseNotify = alert.description {
-                        self.opened = false;
-                        Err(TlsError::ConnectionClosed)
-                    } else {
-                        Err(TlsError::InternalError)
-                    }
-                }
-                ServerRecord::ChangeCipherSpec(_) => Err(TlsError::InternalError),
-                ServerRecord::Handshake(ServerHandshake::NewSessionTicket(_)) => {
-                    // Ignore
-                    Ok(())
-                }
-                _ => {
-                    unimplemented!()
-                }
-            }
+            handler.handle(record)
         })?;
 
         Ok(())

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -204,16 +204,14 @@ where
     }
 
     async fn read_application_data(&mut self) -> Result<(), TlsError> {
-        let buf_ptr = self.record_reader.buf.as_ptr();
-        let buf_len = self.record_reader.buf.len();
+        let buf_ptr_range = self.record_reader.buf.as_ptr_range();
         let record = self
             .record_reader
             .read(&mut self.delegate, &mut self.key_schedule)
             .await?;
 
         let mut handler = DecryptedReadHandler {
-            source_buffer_ptr: buf_ptr,
-            source_buffer_len: buf_len,
+            source_buffer: buf_ptr_range,
             buffer_info: &mut self.decrypted,
             is_open: &mut self.opened,
         };

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -200,15 +200,13 @@ where
     }
 
     fn read_application_data(&mut self) -> Result<(), TlsError> {
-        let buf_ptr = self.record_reader.buf.as_ptr();
-        let buf_len = self.record_reader.buf.len();
+        let buf_ptr_range = self.record_reader.buf.as_ptr_range();
         let record = self
             .record_reader
             .read_blocking(&mut self.delegate, &mut self.key_schedule)?;
 
         let mut handler = DecryptedReadHandler {
-            source_buffer_ptr: buf_ptr,
-            source_buffer_len: buf_len,
+            source_buffer: buf_ptr_range,
             buffer_info: &mut self.decrypted,
             is_open: &mut self.opened,
         };

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -29,7 +29,7 @@ where
 {
     delegate: Socket,
     opened: bool,
-    key_schedule: KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    key_schedule: KeySchedule<CipherSuite>,
     record_reader: RecordReader<'a, CipherSuite>,
     record_write_buf: &'a mut [u8],
     write_pos: usize,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,4 +1,5 @@
 use crate::alert::*;
+use crate::common::decrypted_buffer_info::DecryptedBufferInfo;
 use crate::connection::*;
 use crate::handshake::ServerHandshake;
 use crate::key_schedule::KeySchedule;
@@ -32,9 +33,7 @@ where
     record_reader: RecordReader<'a, CipherSuite>,
     record_write_buf: &'a mut [u8],
     write_pos: usize,
-    decrypted_offset: usize,
-    decrypted_len: usize,
-    decrypted_consumed: usize,
+    decrypted: DecryptedBufferInfo,
 }
 
 impl<'a, Socket, CipherSuite> TlsConnection<'a, Socket, CipherSuite>
@@ -69,9 +68,7 @@ where
             record_reader: RecordReader::new(record_read_buf),
             record_write_buf,
             write_pos: 0,
-            decrypted_offset: 0,
-            decrypted_len: 0,
-            decrypted_consumed: 0,
+            decrypted: DecryptedBufferInfo::default(),
         }
     }
 
@@ -174,12 +171,7 @@ where
     }
 
     fn create_read_buffer(&mut self) -> ReadBuffer {
-        let offset = self.decrypted_offset + self.decrypted_consumed;
-        let end = self.decrypted_offset + self.decrypted_len;
-        ReadBuffer::new(
-            &mut self.record_reader.buf[offset..end],
-            &mut self.decrypted_consumed,
-        )
+        self.decrypted.create_read_buffer(self.record_reader.buf)
     }
 
     /// Read and decrypt data filling the provided slice.
@@ -197,7 +189,7 @@ where
     /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
     pub fn read_buffered(&mut self) -> Result<ReadBuffer, TlsError> {
         if self.opened {
-            while self.need_to_read() {
+            while self.decrypted.is_empty() {
                 self.read_application_data()?;
             }
 
@@ -226,9 +218,9 @@ where
                     let offset = offset as usize;
                     debug_assert!(offset + slice.len() <= buf_len);
 
-                    self.decrypted_offset = offset;
-                    self.decrypted_len = slice.len();
-                    self.decrypted_consumed = 0;
+                    self.decrypted.offset = offset;
+                    self.decrypted.len = slice.len();
+                    self.decrypted.consumed = 0;
                     Ok(())
                 }
                 ServerRecord::Alert(alert) => {
@@ -277,10 +269,6 @@ where
             Ok(()) => Ok(self.delegate),
             Err(e) => Err((self.delegate, e)),
         }
-    }
-
-    fn need_to_read(&self) -> bool {
-        self.decrypted_consumed >= self.decrypted_len
     }
 }
 

--- a/src/common/decrypted_buffer_info.rs
+++ b/src/common/decrypted_buffer_info.rs
@@ -1,0 +1,24 @@
+use crate::read_buffer::ReadBuffer;
+
+#[derive(Default)]
+pub struct DecryptedBufferInfo {
+    pub offset: usize,
+    pub len: usize,
+    pub consumed: usize,
+}
+
+impl DecryptedBufferInfo {
+    pub fn create_read_buffer<'b>(&'b mut self, buffer: &'b [u8]) -> ReadBuffer<'b> {
+        let offset = self.offset + self.consumed;
+        let end = self.offset + self.len;
+        ReadBuffer::new(&buffer[offset..end], &mut self.consumed)
+    }
+
+    pub fn len(&self) -> usize {
+        self.len - self.consumed
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/src/common/decrypted_read_handler.rs
+++ b/src/common/decrypted_read_handler.rs
@@ -1,0 +1,54 @@
+use generic_array::ArrayLength;
+
+use crate::{
+    alert::AlertDescription, common::decrypted_buffer_info::DecryptedBufferInfo,
+    handshake::ServerHandshake, record::ServerRecord, TlsError,
+};
+
+pub struct DecryptedReadHandler<'a> {
+    pub source_buffer_ptr: *const u8,
+    pub source_buffer_len: usize,
+    pub buffer_info: &'a mut DecryptedBufferInfo,
+    pub is_open: &'a mut bool,
+}
+
+impl DecryptedReadHandler<'_> {
+    pub fn handle<N: ArrayLength<u8>>(
+        &mut self,
+        record: ServerRecord<'_, N>,
+    ) -> Result<(), TlsError> {
+        match record {
+            ServerRecord::ApplicationData(data) => {
+                // SAFETY: Assume `decrypt_record()` to decrypt in-place
+                // We have assertions to ensure this is valid.
+                let slice = data.data.as_slice();
+                let slice_ptr = slice.as_ptr();
+                let offset = unsafe { slice_ptr.offset_from(self.source_buffer_ptr) };
+                debug_assert!(offset >= 0);
+                let offset = offset as usize;
+                debug_assert!(offset + slice.len() <= self.source_buffer_len);
+
+                self.buffer_info.offset = offset;
+                self.buffer_info.len = slice.len();
+                self.buffer_info.consumed = 0;
+                Ok(())
+            }
+            ServerRecord::Alert(alert) => {
+                if let AlertDescription::CloseNotify = alert.description {
+                    *self.is_open = false;
+                    Err(TlsError::ConnectionClosed)
+                } else {
+                    Err(TlsError::InternalError)
+                }
+            }
+            ServerRecord::ChangeCipherSpec(_) => Err(TlsError::InternalError),
+            ServerRecord::Handshake(ServerHandshake::NewSessionTicket(_)) => {
+                // Ignore
+                Ok(())
+            }
+            _ => {
+                unimplemented!()
+            }
+        }
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod decrypted_buffer_info;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,1 +1,2 @@
 pub mod decrypted_buffer_info;
+pub mod decrypted_read_handler;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -41,10 +41,10 @@ use aes_gcm::aead::{AeadCore, AeadInPlace, KeyInit};
 use digest::OutputSizeUser;
 
 pub(crate) fn decrypt_record<'m, CipherSuite>(
-    key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    key_schedule: &mut KeySchedule<CipherSuite>,
     record: ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
     mut cb: impl FnMut(
-        &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+        &mut KeySchedule<CipherSuite>,
         ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
     ) -> Result<(), TlsError>,
 ) -> Result<(), TlsError>
@@ -129,7 +129,7 @@ where
 }
 
 pub(crate) fn encrypt<CipherSuite>(
-    key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    key_schedule: &mut KeySchedule<CipherSuite>,
     buf: &mut CryptoBuffer<'_>,
 ) -> Result<usize, TlsError>
 where
@@ -169,7 +169,7 @@ where
 
 pub fn encode_record<'m, CipherSuite>(
     tx_buf: &mut [u8],
-    key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    key_schedule: &mut KeySchedule<CipherSuite>,
     record: &ClientRecord<'_, 'm, CipherSuite>,
 ) -> Result<(CipherSuite::Hash, usize), TlsError>
 where
@@ -227,7 +227,7 @@ where
 pub fn encode_application_data_record_in_place<CipherSuite>(
     tx_buf: &mut [u8],
     data_len: usize,
-    key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    key_schedule: &mut KeySchedule<CipherSuite>,
 ) -> Result<usize, TlsError>
 where
     CipherSuite: TlsCipherSuite + 'static,
@@ -283,7 +283,7 @@ impl<'a> State {
         handshake: &mut Handshake<CipherSuite, Verifier>,
         record_reader: &mut RecordReader<'_, CipherSuite>,
         tx_buf: &mut [u8],
-        key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+        key_schedule: &mut KeySchedule<CipherSuite>,
         config: &TlsConfig<'a, CipherSuite>,
         rng: &mut RNG,
     ) -> Result<State, TlsError>
@@ -396,7 +396,7 @@ impl<'a> State {
         handshake: &mut Handshake<CipherSuite, Verifier>,
         record_reader: &mut RecordReader<'_, CipherSuite>,
         tx_buf: &mut [u8],
-        key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+        key_schedule: &mut KeySchedule<CipherSuite>,
         config: &TlsConfig<'a, CipherSuite>,
         rng: &mut RNG,
     ) -> Result<State, TlsError>
@@ -498,7 +498,7 @@ impl<'a> State {
 
 fn process_server_hello<CipherSuite, Verifier>(
     handshake: &mut Handshake<CipherSuite, Verifier>,
-    key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    key_schedule: &mut KeySchedule<CipherSuite>,
     record: ServerRecord<'_, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
 ) -> Result<(), TlsError>
 where
@@ -529,7 +529,7 @@ where
 
 fn process_server_verify<'a, CipherSuite, Verifier>(
     handshake: &mut Handshake<CipherSuite, Verifier>,
-    key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+    key_schedule: &mut KeySchedule<CipherSuite>,
     config: &TlsConfig<'a, CipherSuite>,
     record: ServerRecord<'_, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
 ) -> Result<State, TlsError>

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,6 +1,6 @@
 use crate::config::{TlsCipherSuite, TlsConfig, TlsVerifier};
 use crate::handshake::{ClientHandshake, ServerHandshake};
-use crate::key_schedule::KeySchedule;
+use crate::key_schedule::{HashOutputSize, KeySchedule};
 use crate::record::{encode_application_data_in_place, ClientRecord, ServerRecord};
 use crate::record_reader::RecordReader;
 use crate::TlsError;
@@ -38,14 +38,13 @@ use crate::content_types::ContentType;
 // use crate::handshake::server_hello::ServerHello;
 use crate::parse_buffer::ParseBuffer;
 use aes_gcm::aead::{AeadCore, AeadInPlace, KeyInit};
-use digest::OutputSizeUser;
 
 pub(crate) fn decrypt_record<'m, CipherSuite>(
     key_schedule: &mut KeySchedule<CipherSuite>,
-    record: ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
+    record: ServerRecord<'m, HashOutputSize<CipherSuite>>,
     mut cb: impl FnMut(
         &mut KeySchedule<CipherSuite>,
-        ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
+        ServerRecord<'m, HashOutputSize<CipherSuite>>,
     ) -> Result<(), TlsError>,
 ) -> Result<(), TlsError>
 where
@@ -193,7 +192,7 @@ where
             // but won't actually be added to the record buffer until the end.
             if let Some((_, identities)) = &hello.config.psk {
                 let binders_len =
-                    identities.len() * (1 + <CipherSuite::Hash as OutputSizeUser>::output_size());
+                    identities.len() * (1 + HashOutputSize::<CipherSuite>::to_usize());
 
                 // NOTE: Exclude the binders_len itself from the digest
                 Digest::update(
@@ -456,8 +455,7 @@ impl<'a> State {
                     certificate.add(cert.into())?;
                 }
                 let client_handshake = ClientHandshake::ClientCert(certificate);
-                let client_cert: ClientRecord<'a, '_, CipherSuite> =
-                    ClientRecord::Handshake(client_handshake, true);
+                let client_cert = ClientRecord::<CipherSuite>::Handshake(client_handshake, true);
 
                 let (next_hash, len) = encode_record(tx_buf, key_schedule, &client_cert)?;
                 transport
@@ -499,7 +497,7 @@ impl<'a> State {
 fn process_server_hello<CipherSuite, Verifier>(
     handshake: &mut Handshake<CipherSuite, Verifier>,
     key_schedule: &mut KeySchedule<CipherSuite>,
-    record: ServerRecord<'_, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
+    record: ServerRecord<'_, HashOutputSize<CipherSuite>>,
 ) -> Result<(), TlsError>
 where
     CipherSuite: TlsCipherSuite + 'static,
@@ -531,7 +529,7 @@ fn process_server_verify<'a, CipherSuite, Verifier>(
     handshake: &mut Handshake<CipherSuite, Verifier>,
     key_schedule: &mut KeySchedule<CipherSuite>,
     config: &TlsConfig<'a, CipherSuite>,
-    record: ServerRecord<'_, <CipherSuite::Hash as OutputSizeUser>::OutputSize>,
+    record: ServerRecord<'_, HashOutputSize<CipherSuite>>,
 ) -> Result<State, TlsError>
 where
     CipherSuite: TlsCipherSuite + 'static,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -326,7 +326,7 @@ impl<'a> State {
                 );*/
                 let record = record_reader.read(transport, key_schedule).await?;
 
-                process_server_verify::<_, Verifier>(handshake, key_schedule, config, record)
+                process_server_verify(handshake, key_schedule, config, record)
             }
             State::ClientCert => {
                 handshake
@@ -438,7 +438,7 @@ impl<'a> State {
                 );*/
                 let record = record_reader.read_blocking(transport, key_schedule)?;
 
-                process_server_verify::<_, Verifier>(handshake, key_schedule, config, record)
+                process_server_verify(handshake, key_schedule, config, record)
             }
             State::ClientCert => {
                 handshake

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -1,6 +1,6 @@
 use crate::handshake::binder::PskBinder;
 use crate::handshake::finished::Finished;
-use crate::{TlsCipherSuite, TlsError};
+use crate::{config::TlsCipherSuite, TlsError};
 use digest::generic_array::ArrayLength;
 use heapless::Vec;
 use hmac::digest::OutputSizeUser;

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -1,35 +1,37 @@
 use crate::handshake::binder::PskBinder;
 use crate::handshake::finished::Finished;
-use crate::TlsError;
-use core::marker::PhantomData;
-use digest::core_api::BlockSizeUser;
+use crate::{TlsCipherSuite, TlsError};
 use digest::generic_array::ArrayLength;
-use digest::Reset;
 use heapless::Vec;
-use hkdf::Hkdf;
 use hmac::digest::OutputSizeUser;
 use hmac::{Mac, SimpleHmac};
 use sha2::digest::generic_array::{typenum::Unsigned, GenericArray};
 use sha2::Digest;
 
-pub struct KeySchedule<D, KeyLen, IvLen>
+pub type HashOutputSize<CipherSuite> =
+    <<CipherSuite as TlsCipherSuite>::Hash as OutputSizeUser>::OutputSize;
+
+pub type IvArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::IvLen>;
+pub type KeyArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::KeyLen>;
+pub type HashArray<CipherSuite> = GenericArray<u8, HashOutputSize<CipherSuite>>;
+
+type Hkdf<CipherSuite> = hkdf::Hkdf<
+    <CipherSuite as TlsCipherSuite>::Hash,
+    SimpleHmac<<CipherSuite as TlsCipherSuite>::Hash>,
+>;
+
+pub struct KeySchedule<CipherSuite>
 where
-    D: Digest + Reset + Clone + OutputSizeUser + BlockSizeUser,
-    <D as BlockSizeUser>::BlockSize: ArrayLength<u8>,
-    <D as OutputSizeUser>::OutputSize: ArrayLength<u8>,
-    KeyLen: ArrayLength<u8>,
-    IvLen: ArrayLength<u8>,
+    CipherSuite: TlsCipherSuite,
 {
-    secret: GenericArray<u8, <D as OutputSizeUser>::OutputSize>,
-    transcript_hash: Option<D>,
-    hkdf: Option<Hkdf<D, SimpleHmac<D>>>,
-    client_traffic_secret: Option<Hkdf<D, SimpleHmac<D>>>,
-    server_traffic_secret: Option<Hkdf<D, SimpleHmac<D>>>,
-    binder_key: Option<Hkdf<D, SimpleHmac<D>>>,
+    secret: HashArray<CipherSuite>,
+    transcript_hash: Option<CipherSuite::Hash>,
+    hkdf: Option<Hkdf<CipherSuite>>,
+    client_traffic_secret: Option<Hkdf<CipherSuite>>,
+    server_traffic_secret: Option<Hkdf<CipherSuite>>,
+    binder_key: Option<Hkdf<CipherSuite>>,
     read_counter: u64,
     write_counter: u64,
-    _key_len: PhantomData<KeyLen>,
-    _iv_len: PhantomData<IvLen>,
 }
 
 enum ContextType {
@@ -38,34 +40,28 @@ enum ContextType {
     EmptyHash,
 }
 
-impl<D, KeyLen, IvLen> KeySchedule<D, KeyLen, IvLen>
+impl<CipherSuite> KeySchedule<CipherSuite>
 where
-    D: Digest + Reset + Clone + OutputSizeUser + BlockSizeUser,
-    <D as BlockSizeUser>::BlockSize: ArrayLength<u8>,
-    <D as OutputSizeUser>::OutputSize: ArrayLength<u8>,
-    KeyLen: ArrayLength<u8>,
-    IvLen: ArrayLength<u8>,
+    CipherSuite: TlsCipherSuite,
 {
     pub fn new() -> Self {
         Self {
             secret: Self::zero(),
-            transcript_hash: Some(D::new()),
+            transcript_hash: Some(CipherSuite::Hash::new()),
             hkdf: None,
             client_traffic_secret: None,
             server_traffic_secret: None,
             binder_key: None,
             read_counter: 0,
             write_counter: 0,
-            _key_len: PhantomData,
-            _iv_len: PhantomData,
         }
     }
 
-    pub(crate) fn transcript_hash(&mut self) -> &mut D {
+    pub(crate) fn transcript_hash(&mut self) -> &mut CipherSuite::Hash {
         self.transcript_hash.as_mut().unwrap()
     }
 
-    pub(crate) fn replace_transcript_hash(&mut self, hash: D) {
+    pub(crate) fn replace_transcript_hash(&mut self, hash: CipherSuite::Hash) {
         self.transcript_hash.replace(hash);
     }
 
@@ -81,51 +77,56 @@ where
         self.write_counter = 0;
     }
 
-    pub(crate) fn get_server_nonce(&self) -> Result<GenericArray<u8, IvLen>, TlsError> {
+    pub(crate) fn get_server_nonce(&self) -> Result<IvArray<CipherSuite>, TlsError> {
         Ok(self.get_nonce(self.read_counter, &self.get_server_iv()?))
     }
 
-    pub(crate) fn get_client_nonce(&self) -> Result<GenericArray<u8, IvLen>, TlsError> {
+    pub(crate) fn get_client_nonce(&self) -> Result<IvArray<CipherSuite>, TlsError> {
         Ok(self.get_nonce(self.write_counter, &self.get_client_iv()?))
     }
 
-    pub(crate) fn get_server_key(&self) -> Result<GenericArray<u8, KeyLen>, TlsError> {
+    pub(crate) fn get_server_key(&self) -> Result<KeyArray<CipherSuite>, TlsError> {
         self.hkdf_expand_label(
             self.server_traffic_secret.as_ref().unwrap(),
-            &self.make_hkdf_label(b"key", ContextType::None, KeyLen::to_u16())?,
+            &self.make_hkdf_label(b"key", ContextType::None, CipherSuite::KeyLen::to_u16())?,
         )
     }
 
-    pub(crate) fn get_client_key(&self) -> Result<GenericArray<u8, KeyLen>, TlsError> {
+    pub(crate) fn get_client_key(&self) -> Result<KeyArray<CipherSuite>, TlsError> {
         self.hkdf_expand_label(
             self.client_traffic_secret.as_ref().unwrap(),
-            &self.make_hkdf_label(b"key", ContextType::None, KeyLen::to_u16())?,
+            &self.make_hkdf_label(b"key", ContextType::None, CipherSuite::KeyLen::to_u16())?,
         )
     }
 
-    fn get_server_iv(&self) -> Result<GenericArray<u8, IvLen>, TlsError> {
+    fn get_server_iv(&self) -> Result<IvArray<CipherSuite>, TlsError> {
         self.hkdf_expand_label(
             self.server_traffic_secret.as_ref().unwrap(),
-            &self.make_hkdf_label(b"iv", ContextType::None, IvLen::to_u16())?,
+            &self.make_hkdf_label(b"iv", ContextType::None, CipherSuite::IvLen::to_u16())?,
         )
     }
 
-    fn get_client_iv(&self) -> Result<GenericArray<u8, IvLen>, TlsError> {
+    fn get_client_iv(&self) -> Result<IvArray<CipherSuite>, TlsError> {
         self.hkdf_expand_label(
             self.client_traffic_secret.as_ref().unwrap(),
-            &self.make_hkdf_label(b"iv", ContextType::None, IvLen::to_u16())?,
+            &self.make_hkdf_label(b"iv", ContextType::None, CipherSuite::IvLen::to_u16())?,
         )
     }
 
     pub fn create_client_finished(
         &self,
-    ) -> Result<Finished<<D as OutputSizeUser>::OutputSize>, TlsError> {
-        let key: GenericArray<u8, D::OutputSize> = self.hkdf_expand_label(
+    ) -> Result<Finished<HashOutputSize<CipherSuite>>, TlsError> {
+        let key = self.hkdf_expand_label::<HashOutputSize<CipherSuite>>(
             self.client_traffic_secret.as_ref().unwrap(),
-            &self.make_hkdf_label(b"finished", ContextType::None, D::OutputSize::to_u16())?,
+            &self.make_hkdf_label(
+                b"finished",
+                ContextType::None,
+                HashOutputSize::<CipherSuite>::to_u16(),
+            )?,
         )?;
 
-        let mut hmac = SimpleHmac::<D>::new_from_slice(&key).map_err(|_| TlsError::CryptoError)?;
+        let mut hmac = SimpleHmac::<CipherSuite::Hash>::new_from_slice(&key)
+            .map_err(|_| TlsError::CryptoError)?;
         Mac::update(
             &mut hmac,
             &self.transcript_hash.as_ref().unwrap().clone().finalize(),
@@ -135,15 +136,18 @@ where
         Ok(Finished { verify, hash: None })
     }
 
-    pub fn create_psk_binder(
-        &self,
-    ) -> Result<PskBinder<<D as OutputSizeUser>::OutputSize>, TlsError> {
-        let key: GenericArray<u8, D::OutputSize> = self.hkdf_expand_label(
+    pub fn create_psk_binder(&self) -> Result<PskBinder<HashOutputSize<CipherSuite>>, TlsError> {
+        let key = self.hkdf_expand_label::<HashOutputSize<CipherSuite>>(
             self.binder_key.as_ref().unwrap(),
-            &self.make_hkdf_label(b"finished", ContextType::None, D::OutputSize::to_u16())?,
+            &self.make_hkdf_label(
+                b"finished",
+                ContextType::None,
+                HashOutputSize::<CipherSuite>::to_u16(),
+            )?,
         )?;
 
-        let mut hmac = SimpleHmac::<D>::new_from_slice(&key).map_err(|_| TlsError::CryptoError)?;
+        let mut hmac = SimpleHmac::<CipherSuite::Hash>::new_from_slice(&key)
+            .map_err(|_| TlsError::CryptoError)?;
         Mac::update(
             &mut hmac,
             &self.transcript_hash.as_ref().unwrap().clone().finalize(),
@@ -154,17 +158,21 @@ where
 
     pub fn verify_server_finished(
         &self,
-        finished: &Finished<<D as OutputSizeUser>::OutputSize>,
+        finished: &Finished<HashOutputSize<CipherSuite>>,
     ) -> Result<bool, TlsError> {
         //info!("verify server finished: {:x?}", finished.verify);
         //self.client_traffic_secret.as_ref().unwrap().expand()
         //info!("size ===> {}", D::OutputSize::to_u16());
-        let key: GenericArray<u8, D::OutputSize> = self.hkdf_expand_label(
+        let key = self.hkdf_expand_label::<HashOutputSize<CipherSuite>>(
             self.server_traffic_secret.as_ref().unwrap(),
-            &self.make_hkdf_label(b"finished", ContextType::None, D::OutputSize::to_u16())?,
+            &self.make_hkdf_label(
+                b"finished",
+                ContextType::None,
+                HashOutputSize::<CipherSuite>::to_u16(),
+            )?,
         )?;
         // info!("hmac sign key {:x?}", key);
-        let mut hmac = SimpleHmac::<D>::new_from_slice(&key).unwrap();
+        let mut hmac = SimpleHmac::<CipherSuite::Hash>::new_from_slice(&key).unwrap();
         Mac::update(&mut hmac, finished.hash.as_ref().unwrap());
         //let code = hmac.clone().finalize().into_bytes();
         Ok(hmac.verify(&finished.verify).is_ok())
@@ -172,21 +180,21 @@ where
         //unimplemented!()
     }
 
-    fn get_nonce(&self, counter: u64, iv: &GenericArray<u8, IvLen>) -> GenericArray<u8, IvLen> {
+    fn get_nonce(&self, counter: u64, iv: &IvArray<CipherSuite>) -> IvArray<CipherSuite> {
         //info!("counter = {} {:x?}", counter, &counter.to_be_bytes(),);
-        let counter = Self::pad::<IvLen>(&counter.to_be_bytes());
+        let counter = Self::pad::<CipherSuite::IvLen>(&counter.to_be_bytes());
 
         //info!("counter = {:x?}", counter);
         // info!("iv = {:x?}", iv);
 
         let mut nonce = GenericArray::default();
 
-        for (index, (l, r)) in iv[0..IvLen::to_usize()]
+        for (index, (l, r)) in iv[0..CipherSuite::IvLen::to_usize()]
             .iter()
             .zip(counter.iter())
             .enumerate()
         {
-            nonce[index] = l ^ r
+            nonce[index] = l ^ r;
         }
 
         //debug!("nonce {:x?}", nonce);
@@ -209,7 +217,7 @@ where
         padded
     }
 
-    fn zero() -> GenericArray<u8, <D as OutputSizeUser>::OutputSize> {
+    fn zero() -> HashArray<CipherSuite> {
         GenericArray::default()
     }
 
@@ -218,34 +226,34 @@ where
         Ok(())
     }
 
+    fn initialize(&mut self, ikm: &[u8]) {
+        let (secret, hkdf) = Hkdf::<CipherSuite>::extract(Some(self.secret.as_ref()), ikm);
+        self.hkdf = Some(hkdf);
+        self.secret = secret;
+    }
+
     // Initializes the early secrets with a callback for any PSK binders
     pub fn initialize_early_secret(&mut self, psk: Option<&[u8]>) -> Result<(), TlsError> {
-        let (secret, hkdf) = Hkdf::<D, SimpleHmac<D>>::extract(
-            Some(self.secret.as_ref()),
+        self.initialize(
             #[allow(clippy::or_fun_call)]
             psk.unwrap_or(Self::zero().as_slice()),
         );
-        self.hkdf.replace(hkdf);
-        self.secret = secret;
+
         let binder_key = self.derive_secret(b"ext binder", ContextType::EmptyHash)?;
         self.binder_key
-            .replace(Hkdf::from_prk(&binder_key).unwrap());
+            .replace(Hkdf::<CipherSuite>::from_prk(&binder_key).unwrap());
         self.derived()
     }
 
     pub fn initialize_handshake_secret(&mut self, ikm: &[u8]) -> Result<(), TlsError> {
-        let (secret, hkdf) = Hkdf::<D, SimpleHmac<D>>::extract(Some(self.secret.as_ref()), ikm);
-        self.secret = secret;
-        self.hkdf.replace(hkdf);
+        self.initialize(ikm);
+
         self.calculate_traffic_secrets(b"c hs traffic", b"s hs traffic")?;
         self.derived()
     }
 
     pub fn initialize_master_secret(&mut self) -> Result<(), TlsError> {
-        let (secret, hkdf) =
-            Hkdf::<D, SimpleHmac<D>>::extract(Some(self.secret.as_ref()), Self::zero().as_slice());
-        self.secret = secret;
-        self.hkdf.replace(hkdf);
+        self.initialize(Self::zero().as_slice());
 
         //let context = self.transcript_hash.as_ref().unwrap().clone().finalize();
         //info!("Derive keys, hash: {:x?}", context);
@@ -261,7 +269,7 @@ where
     ) -> Result<(), TlsError> {
         let client_secret = self.derive_secret(client_label, ContextType::TranscriptHash)?;
         self.client_traffic_secret
-            .replace(Hkdf::from_prk(&client_secret).unwrap());
+            .replace(Hkdf::<CipherSuite>::from_prk(&client_secret).unwrap());
         /*info!(
             "\n\nTRAFFIC {} secret {:x?}",
             core::str::from_utf8(client_label).unwrap(),
@@ -269,7 +277,7 @@ where
         );*/
         let server_secret = self.derive_secret(server_label, ContextType::TranscriptHash)?;
         self.server_traffic_secret
-            .replace(Hkdf::from_prk(&server_secret).unwrap());
+            .replace(Hkdf::<CipherSuite>::from_prk(&server_secret).unwrap());
         /*info!(
             "TRAFFIC {} secret {:x?}\n\n",
             core::str::from_utf8(server_label).unwrap(),
@@ -284,17 +292,19 @@ where
         &mut self,
         label: &[u8],
         context_type: ContextType,
-    ) -> Result<GenericArray<u8, <D as OutputSizeUser>::OutputSize>, TlsError> {
-        let label = self.make_hkdf_label(label, context_type, D::OutputSize::to_u16())?;
-        self.hkdf_expand_label(self.hkdf.as_ref().unwrap(), &label)
+    ) -> Result<HashArray<CipherSuite>, TlsError> {
+        self.hkdf_expand_label(
+            self.hkdf.as_ref().unwrap(),
+            &self.make_hkdf_label(label, context_type, HashOutputSize::<CipherSuite>::to_u16())?,
+        )
     }
 
     pub fn hkdf_expand_label<N: ArrayLength<u8>>(
         &self,
-        hkdf: &Hkdf<D, SimpleHmac<D>>,
+        hkdf: &Hkdf<CipherSuite>,
         label: &[u8],
     ) -> Result<GenericArray<u8, N>, TlsError> {
-        let mut okm: GenericArray<u8, N> = Default::default();
+        let mut okm = GenericArray::default();
         //info!("label {:x?}", label);
         hkdf.expand(label, &mut okm)
             .map_err(|_| TlsError::CryptoError)?;
@@ -339,7 +349,7 @@ where
                     .map_err(|_| TlsError::InternalError)?;
             }
             ContextType::EmptyHash => {
-                let context = D::new().chain_update([]).finalize();
+                let context = CipherSuite::Hash::new().chain_update([]).finalize();
                 hkdf_label
                     .extend_from_slice(&(context.len() as u8).to_be_bytes())
                     .map_err(|_| TlsError::InternalError)?;
@@ -352,13 +362,9 @@ where
     }
 }
 
-impl<D, KeyLen, IvLen> Default for KeySchedule<D, KeyLen, IvLen>
+impl<CipherSuite> Default for KeySchedule<CipherSuite>
 where
-    D: Digest + Reset + Clone + OutputSizeUser + BlockSizeUser,
-    <D as BlockSizeUser>::BlockSize: ArrayLength<u8>,
-    <D as OutputSizeUser>::OutputSize: ArrayLength<u8>,
-    KeyLen: ArrayLength<u8>,
-    IvLen: ArrayLength<u8>,
+    CipherSuite: TlsCipherSuite,
 {
     fn default() -> Self {
         KeySchedule::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ mod buffer;
 mod certificate_types;
 mod change_cipher_spec;
 mod cipher_suites;
+mod common;
 mod config;
 mod connection;
 mod content_types;

--- a/src/record_reader.rs
+++ b/src/record_reader.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use digest::OutputSizeUser;
+use crate::key_schedule::HashOutputSize;
 use embedded_io::{blocking::Read as BlockingRead, Error};
 
 #[cfg(feature = "async")]
@@ -43,7 +43,7 @@ where
         &'m mut self,
         transport: &mut impl AsyncRead,
         key_schedule: &mut KeySchedule<CipherSuite>,
-    ) -> Result<ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>, TlsError>
+    ) -> Result<ServerRecord<'m, HashOutputSize<CipherSuite>>, TlsError>
     where
         CipherSuite: TlsCipherSuite + 'static,
     {
@@ -84,7 +84,7 @@ where
         &'m mut self,
         transport: &mut impl BlockingRead,
         key_schedule: &mut KeySchedule<CipherSuite>,
-    ) -> Result<ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>, TlsError>
+    ) -> Result<ServerRecord<'m, HashOutputSize<CipherSuite>>, TlsError>
     where
         CipherSuite: TlsCipherSuite + 'static,
     {

--- a/src/record_reader.rs
+++ b/src/record_reader.rs
@@ -52,7 +52,7 @@ where
 
         let content_length = header.content_length();
         let data = self.advance(transport, content_length).await?;
-        ServerRecord::decode::<CipherSuite::Hash>(header, data, key_schedule.transcript_hash())
+        ServerRecord::decode(header, data, key_schedule.transcript_hash())
     }
 
     #[cfg(feature = "async")]
@@ -100,7 +100,7 @@ where
 
         let content_length = header.content_length();
         let data = self.advance_blocking(transport, content_length)?;
-        ServerRecord::decode::<CipherSuite::Hash>(header, data, key_schedule.transcript_hash())
+        ServerRecord::decode(header, data, key_schedule.transcript_hash())
     }
 
     fn advance_blocking<'m>(

--- a/src/record_reader.rs
+++ b/src/record_reader.rs
@@ -42,7 +42,7 @@ where
     pub async fn read<'m>(
         &'m mut self,
         transport: &mut impl AsyncRead,
-        key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+        key_schedule: &mut KeySchedule<CipherSuite>,
     ) -> Result<ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>, TlsError>
     where
         CipherSuite: TlsCipherSuite + 'static,
@@ -83,7 +83,7 @@ where
     pub fn read_blocking<'m>(
         &'m mut self,
         transport: &mut impl BlockingRead,
-        key_schedule: &mut KeySchedule<CipherSuite::Hash, CipherSuite::KeyLen, CipherSuite::IvLen>,
+        key_schedule: &mut KeySchedule<CipherSuite>,
     ) -> Result<ServerRecord<'m, <CipherSuite::Hash as OutputSizeUser>::OutputSize>, TlsError>
     where
         CipherSuite: TlsCipherSuite + 'static,
@@ -138,7 +138,7 @@ mod tests {
     use core::convert::Infallible;
 
     use super::*;
-    use crate::{content_types::ContentType, Aes128GcmSha256, TlsCipherSuite};
+    use crate::{content_types::ContentType, Aes128GcmSha256};
 
     struct ChunkRead<'a>(&'a [u8], usize);
 
@@ -205,11 +205,7 @@ mod tests {
 
         let mut buf = [0; 32];
         let mut reader = RecordReader::<Aes128GcmSha256>::new(&mut buf);
-        let mut key_schedule = KeySchedule::<
-            <Aes128GcmSha256 as TlsCipherSuite>::Hash,
-            <Aes128GcmSha256 as TlsCipherSuite>::KeyLen,
-            <Aes128GcmSha256 as TlsCipherSuite>::IvLen,
-        >::new();
+        let mut key_schedule = KeySchedule::<Aes128GcmSha256>::new();
 
         {
             if let ServerRecord::ApplicationData(data) = reader
@@ -268,11 +264,7 @@ mod tests {
 
         let mut buf = [0; 5]; // This buffer is so small that it cannot contain both the header and data
         let mut reader = RecordReader::<Aes128GcmSha256>::new(&mut buf);
-        let mut key_schedule = KeySchedule::<
-            <Aes128GcmSha256 as TlsCipherSuite>::Hash,
-            <Aes128GcmSha256 as TlsCipherSuite>::KeyLen,
-            <Aes128GcmSha256 as TlsCipherSuite>::IvLen,
-        >::new();
+        let mut key_schedule = KeySchedule::<Aes128GcmSha256>::new();
 
         {
             if let ServerRecord::ApplicationData(data) = reader
@@ -324,11 +316,7 @@ mod tests {
 
         let mut buf = [0; 32];
         let mut reader = RecordReader::<Aes128GcmSha256>::new(&mut buf);
-        let mut key_schedule = KeySchedule::<
-            <Aes128GcmSha256 as TlsCipherSuite>::Hash,
-            <Aes128GcmSha256 as TlsCipherSuite>::KeyLen,
-            <Aes128GcmSha256 as TlsCipherSuite>::IvLen,
-        >::new();
+        let mut key_schedule = KeySchedule::<Aes128GcmSha256>::new();
 
         {
             if let ServerRecord::ApplicationData(data) = reader

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -67,7 +67,7 @@ where
         let handshake_hash = self.certificate_transcript.take().unwrap();
         let ctx_str = b"TLS 1.3, server CertificateVerify\x00";
         let mut msg: Vec<u8, 130> = Vec::new();
-        msg.resize(64, 0x20u8).map_err(|_| TlsError::EncodeError)?;
+        msg.resize(64, 0x20).map_err(|_| TlsError::EncodeError)?;
         msg.extend_from_slice(ctx_str)
             .map_err(|_| TlsError::EncodeError)?;
         msg.extend_from_slice(&handshake_hash.finalize())


### PR DESCRIPTION
This PR extracts some common code from the async and blocking implementations, and includes some additional cleanup like using a single type parameter for KeySchedule.