### PR TITLE
Allow splitting a connection into read/write parts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,9 @@ pem-parser = "0.1.1"
 openssl = "0.10.44"
 
 [features]
-default = ["std", "async", "log", "tokio", "split"]
+default = ["std", "async", "log", "tokio"]
 defmt = ["dep:defmt", "embedded-io/defmt", "heapless/defmt-impl"]
 std = ["embedded-io/std"]
 tokio = ["embedded-io/tokio"]
 async = ["embedded-io/async"]
 alloc = []
-split = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,10 @@ pem-parser = "0.1.1"
 openssl = "0.10.44"
 
 [features]
-default = ["std", "async", "log", "tokio"]
+default = ["std", "async", "log", "tokio", "split"]
 defmt = ["dep:defmt", "embedded-io/defmt", "heapless/defmt-impl"]
 std = ["embedded-io/std"]
 tokio = ["embedded-io/tokio"]
 async = ["embedded-io/async"]
 alloc = []
+split = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["embedded", "async", "tls", "no_std", "network"]
 exclude = [".github"]
 
 [dependencies]
+atomic-polyfill = "1"
 p256 = { version = "0.11", default-features = false, features = [ "ecdh", "arithmetic" ] }
 rand_core = { version = "0.6.3", default-features = false }
 hkdf = "0.12.3"

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -469,6 +469,21 @@ where
     }
 }
 
+impl<'a, Socket, CipherSuite, State> BufRead for TlsReader<'a, Socket, CipherSuite, State>
+where
+    Socket: AsyncRead + 'a,
+    CipherSuite: TlsCipherSuite + 'static,
+    State: SplitState,
+{
+    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+        self.read_buffered().await.map(|mut buf| buf.peek_all())
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.create_read_buffer().pop(amt);
+    }
+}
+
 impl<'a, Socket, CipherSuite, State> AsyncWrite for TlsWriter<'a, Socket, CipherSuite, State>
 where
     Socket: AsyncWrite + 'a,

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -2,9 +2,11 @@ use crate::common::decrypted_buffer_info::DecryptedBufferInfo;
 use crate::common::decrypted_read_handler::DecryptedReadHandler;
 use crate::connection::*;
 use crate::key_schedule::KeySchedule;
+use crate::key_schedule::{ReadKeySchedule, SharedState, WriteKeySchedule};
 use crate::read_buffer::ReadBuffer;
 use crate::record::{ClientRecord, ClientRecordHeader};
 use crate::record_reader::RecordReader;
+use crate::split::SplitState;
 use crate::write_buffer::WriteBuffer;
 use crate::TlsError;
 use embedded_io::asynch::BufRead;
@@ -16,6 +18,9 @@ use embedded_io::{
 use rand_core::{CryptoRng, RngCore};
 
 pub use crate::config::*;
+#[cfg(feature = "std")]
+pub use crate::split::ManagedSplitState;
+pub use crate::split::SplitConnectionState;
 
 /// Type representing an async TLS connection. An instance of this type can
 /// be used to establish a TLS connection, write and read encrypted data over this connection,
@@ -230,28 +235,74 @@ where
         }
     }
 
-    #[cfg(feature = "split")]
+    #[cfg(feature = "std")]
     pub fn split(
         self,
     ) -> (
-        TlsReader<'a, Socket, CipherSuite>,
-        TlsWriter<'a, Socket, CipherSuite>,
+        TlsReader<'a, Socket, CipherSuite, ManagedSplitState>,
+        TlsWriter<'a, Socket, CipherSuite, ManagedSplitState>,
     )
     where
         Socket: Clone,
     {
-        split::split(self)
+        self.split_with(ManagedSplitState::default())
     }
 
-    #[cfg(feature = "split")]
-    pub fn unsplit(
-        reader: TlsReader<'a, Socket, CipherSuite>,
-        writer: TlsWriter<'a, Socket, CipherSuite>,
+    pub fn split_with<State>(
+        self,
+        state: State,
+    ) -> (
+        TlsReader<'a, Socket, CipherSuite, State>,
+        TlsWriter<'a, Socket, CipherSuite, State>,
+    )
+    where
+        Socket: Clone,
+        State: SplitState,
+    {
+        state.set_open(self.opened);
+
+        let (shared, wks, rks) = self.key_schedule.split();
+
+        let reader = TlsReader {
+            state: state.clone(),
+            delegate: self.delegate.clone(),
+            key_schedule: rks,
+            record_reader: self.record_reader,
+            decrypted: self.decrypted,
+        };
+        let writer = TlsWriter {
+            state,
+            delegate: self.delegate,
+            key_schedule_shared: shared,
+            key_schedule: wks,
+            record_write_buf: self.record_write_buf,
+        };
+
+        (reader, writer)
+    }
+
+    pub fn unsplit<State>(
+        reader: TlsReader<'a, Socket, CipherSuite, State>,
+        writer: TlsWriter<'a, Socket, CipherSuite, State>,
     ) -> Self
     where
         Socket: Clone,
+        State: SplitState,
     {
-        split::unsplit(reader, writer)
+        debug_assert!(reader.state.same(&writer.state));
+
+        TlsConnection {
+            delegate: writer.delegate,
+            opened: writer.state.is_open(),
+            key_schedule: KeySchedule::unsplit(
+                writer.key_schedule_shared,
+                writer.key_schedule,
+                reader.key_schedule,
+            ),
+            record_reader: reader.record_reader,
+            record_write_buf: writer.record_write_buf,
+            decrypted: reader.decrypted,
+        }
     }
 }
 
@@ -301,240 +352,164 @@ where
     }
 }
 
-#[cfg(feature = "split")]
-mod split {
-    use super::*;
+pub struct TlsReader<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    state: State,
+    delegate: Socket,
+    key_schedule: ReadKeySchedule<CipherSuite>,
+    record_reader: RecordReader<'a, CipherSuite>,
+    decrypted: DecryptedBufferInfo,
+}
 
-    use crate::key_schedule::{ReadKeySchedule, SharedState, WriteKeySchedule};
-    use core::sync::atomic::Ordering;
-    use std::{sync::atomic::AtomicBool, sync::Arc};
-
-    pub struct TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncRead + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        opened: Arc<AtomicBool>,
-        delegate: Socket,
-        key_schedule: ReadKeySchedule<CipherSuite>,
-        record_reader: RecordReader<'a, CipherSuite>,
-        decrypted: DecryptedBufferInfo,
-    }
-
-    impl<'a, Socket, CipherSuite> AsRef<Socket> for TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncRead + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        fn as_ref(&self) -> &Socket {
-            &self.delegate
-        }
-    }
-
-    impl<'a, Socket, CipherSuite> TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncRead + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        fn create_read_buffer(&mut self) -> ReadBuffer {
-            self.decrypted.create_read_buffer(self.record_reader.buf)
-        }
-
-        /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
-        pub async fn read_buffered(&mut self) -> Result<ReadBuffer, TlsError> {
-            if self.opened.load(Ordering::Acquire) {
-                while self.decrypted.is_empty() {
-                    self.read_application_data().await?;
-                }
-
-                Ok(self.create_read_buffer())
-            } else {
-                Err(TlsError::MissingHandshake)
-            }
-        }
-
-        async fn read_application_data(&mut self) -> Result<(), TlsError> {
-            let buf_ptr_range = self.record_reader.buf.as_ptr_range();
-            let record = self
-                .record_reader
-                .read(&mut self.delegate, &mut self.key_schedule)
-                .await?;
-
-            let mut opened = self.opened.load(Ordering::Acquire);
-            let mut handler = DecryptedReadHandler {
-                source_buffer: buf_ptr_range,
-                buffer_info: &mut self.decrypted,
-                is_open: &mut opened,
-            };
-            let result = decrypt_record(&mut self.key_schedule, record, |_key_schedule, record| {
-                handler.handle(record)
-            });
-
-            if !opened {
-                self.opened.store(false, Ordering::Release);
-            }
-            result
-        }
-    }
-
-    pub struct TlsWriter<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncWrite + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        opened: Arc<AtomicBool>,
-        delegate: Socket,
-        key_schedule_shared: SharedState<CipherSuite>,
-        key_schedule: WriteKeySchedule<CipherSuite>,
-        record_write_buf: &'a mut [u8],
-        write_pos: usize,
-    }
-
-    impl<'a, Socket, CipherSuite> AsRef<Socket> for TlsWriter<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncWrite + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        fn as_ref(&self) -> &Socket {
-            &self.delegate
-        }
-    }
-
-    impl<'a, Socket, CipherSuite> Io for TlsWriter<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncWrite + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        type Error = TlsError;
-    }
-
-    impl<'a, Socket, CipherSuite> Io for TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncRead + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        type Error = TlsError;
-    }
-
-    impl<'a, Socket, CipherSuite> AsyncRead for TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncRead + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-            let mut buffer = self.read_buffered().await?;
-
-            let len = buffer.pop_into(buf);
-            trace!("Copied {} bytes", len);
-
-            Ok(len)
-        }
-    }
-
-    impl<'a, Socket, CipherSuite> AsyncWrite for TlsWriter<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncWrite + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-            if self.opened.load(Ordering::Acquire) {
-                let max_block_size = self.record_write_buf.len() - TLS_RECORD_OVERHEAD;
-                let buffered = usize::min(buf.len(), max_block_size - self.write_pos);
-                if buffered > 0 {
-                    self.record_write_buf[self.write_pos..self.write_pos + buffered]
-                        .copy_from_slice(&buf[..buffered]);
-                    self.write_pos += buffered;
-                }
-
-                if self.write_pos == max_block_size {
-                    self.flush().await?;
-                }
-
-                Ok(buffered)
-            } else {
-                Err(TlsError::MissingHandshake)
-            }
-        }
-
-        async fn flush(&mut self) -> Result<(), Self::Error> {
-            if self.write_pos > 0 {
-                let len = encode_application_data_record_in_place(
-                    self.record_write_buf,
-                    self.write_pos,
-                    &mut self.key_schedule,
-                )?;
-
-                self.delegate
-                    .write_all(&self.record_write_buf[..len])
-                    .await
-                    .map_err(|e| TlsError::Io(e.kind()))?;
-
-                self.key_schedule.increment_counter();
-                self.write_pos = 0;
-            }
-
-            Ok(())
-        }
-    }
-
-    pub(super) fn split<'a, Socket, CipherSuite>(
-        connection: TlsConnection<'a, Socket, CipherSuite>,
-    ) -> (
-        TlsReader<'a, Socket, CipherSuite>,
-        TlsWriter<'a, Socket, CipherSuite>,
-    )
-    where
-        Socket: AsyncRead + AsyncWrite + 'a,
-        Socket: Clone,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        let opened = Arc::new(AtomicBool::new(connection.opened));
-        let (shared, wks, rks) = connection.key_schedule.split();
-
-        let reader = TlsReader {
-            opened: opened.clone(),
-            delegate: connection.delegate.clone(),
-            key_schedule: rks,
-            record_reader: connection.record_reader,
-            decrypted: connection.decrypted,
-        };
-        let writer = TlsWriter {
-            opened,
-            delegate: connection.delegate,
-            key_schedule_shared: shared,
-            key_schedule: wks,
-            record_write_buf: connection.record_write_buf,
-            write_pos: connection.write_pos,
-        };
-
-        (reader, writer)
-    }
-
-    pub(super) fn unsplit<'a, Socket, CipherSuite>(
-        reader: TlsReader<'a, Socket, CipherSuite>,
-        writer: TlsWriter<'a, Socket, CipherSuite>,
-    ) -> TlsConnection<'a, Socket, CipherSuite>
-    where
-        Socket: AsyncRead + AsyncWrite + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        debug_assert!(Arc::ptr_eq(&reader.opened, &writer.opened));
-
-        TlsConnection {
-            delegate: writer.delegate,
-            opened: writer.opened.load(Ordering::Relaxed),
-            key_schedule: KeySchedule::unsplit(
-                writer.key_schedule_shared,
-                writer.key_schedule,
-                reader.key_schedule,
-            ),
-            record_reader: reader.record_reader,
-            record_write_buf: writer.record_write_buf,
-            write_pos: writer.write_pos,
-            decrypted: reader.decrypted,
-        }
+impl<'a, Socket, CipherSuite, State> AsRef<Socket> for TlsReader<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    fn as_ref(&self) -> &Socket {
+        &self.delegate
     }
 }
 
-#[cfg(feature = "split")]
-pub use split::{TlsReader, TlsWriter};
+impl<'a, Socket, CipherSuite, State> TlsReader<'a, Socket, CipherSuite, State>
+where
+    Socket: AsyncRead + 'a,
+    CipherSuite: TlsCipherSuite + 'static,
+    State: SplitState,
+{
+    fn create_read_buffer(&mut self) -> ReadBuffer {
+        self.decrypted.create_read_buffer(self.record_reader.buf)
+    }
+
+    /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
+    pub async fn read_buffered(&mut self) -> Result<ReadBuffer, TlsError> {
+        if self.state.is_open() {
+            while self.decrypted.is_empty() {
+                self.read_application_data().await?;
+            }
+
+            Ok(self.create_read_buffer())
+        } else {
+            Err(TlsError::MissingHandshake)
+        }
+    }
+
+    async fn read_application_data(&mut self) -> Result<(), TlsError> {
+        let buf_ptr_range = self.record_reader.buf.as_ptr_range();
+        let record = self
+            .record_reader
+            .read(&mut self.delegate, &mut self.key_schedule)
+            .await?;
+
+        let mut opened = self.state.is_open();
+        let mut handler = DecryptedReadHandler {
+            source_buffer: buf_ptr_range,
+            buffer_info: &mut self.decrypted,
+            is_open: &mut opened,
+        };
+        let result = decrypt_record(&mut self.key_schedule, record, |_key_schedule, record| {
+            handler.handle(record)
+        });
+
+        if !opened {
+            self.state.set_open(false);
+        }
+        result
+    }
+}
+
+pub struct TlsWriter<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    state: State,
+    delegate: Socket,
+    key_schedule_shared: SharedState<CipherSuite>,
+    key_schedule: WriteKeySchedule<CipherSuite>,
+    record_write_buf: WriteBuffer<'a>,
+}
+
+impl<'a, Socket, CipherSuite, State> AsRef<Socket> for TlsWriter<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    fn as_ref(&self) -> &Socket {
+        &self.delegate
+    }
+}
+
+impl<'a, Socket, CipherSuite, State> Io for TlsWriter<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    type Error = TlsError;
+}
+
+impl<'a, Socket, CipherSuite, State> Io for TlsReader<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    type Error = TlsError;
+}
+
+impl<'a, Socket, CipherSuite, State> AsyncRead for TlsReader<'a, Socket, CipherSuite, State>
+where
+    Socket: AsyncRead + 'a,
+    CipherSuite: TlsCipherSuite + 'static,
+    State: SplitState,
+{
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let mut buffer = self.read_buffered().await?;
+
+        let len = buffer.pop_into(buf);
+        trace!("Copied {} bytes", len);
+
+        Ok(len)
+    }
+}
+
+impl<'a, Socket, CipherSuite, State> AsyncWrite for TlsWriter<'a, Socket, CipherSuite, State>
+where
+    Socket: AsyncWrite + 'a,
+    CipherSuite: TlsCipherSuite + 'static,
+    State: SplitState,
+{
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        if self.state.is_open() {
+            if !self
+                .record_write_buf
+                .contains(ClientRecordHeader::ApplicationData)
+            {
+                self.flush().await?;
+                self.record_write_buf
+                    .start_record(ClientRecordHeader::ApplicationData)?;
+            }
+
+            let buffered = self.record_write_buf.append(buf);
+
+            if self.record_write_buf.is_full() {
+                self.flush().await?;
+            }
+
+            Ok(buffered)
+        } else {
+            Err(TlsError::MissingHandshake)
+        }
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        if !self.record_write_buf.is_empty() {
+            let slice = self.record_write_buf.close_record(&mut self.key_schedule)?;
+
+            self.delegate
+                .write_all(slice)
+                .await
+                .map_err(|e| TlsError::Io(e.kind()))?;
+
+            self.key_schedule.increment_counter();
+        }
+
+        Ok(())
+    }
+}

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -6,7 +6,7 @@ use crate::key_schedule::{ReadKeySchedule, SharedState, WriteKeySchedule};
 use crate::read_buffer::ReadBuffer;
 use crate::record::{ClientRecord, ClientRecordHeader};
 use crate::record_reader::RecordReader;
-use crate::split::SplitState;
+use crate::split::{SplitState, SplitStateContainer};
 use crate::write_buffer::WriteBuffer;
 use crate::TlsError;
 use embedded_io::asynch::BufRead;
@@ -245,20 +245,21 @@ where
     where
         Socket: Clone,
     {
-        self.split_with(ManagedSplitState::default())
+        self.split_with(ManagedSplitState::new())
     }
 
-    pub fn split_with<State>(
+    pub fn split_with<StateContainer>(
         self,
-        state: State,
+        state: StateContainer,
     ) -> (
-        TlsReader<'a, Socket, CipherSuite, State>,
-        TlsWriter<'a, Socket, CipherSuite, State>,
+        TlsReader<'a, Socket, CipherSuite, StateContainer::State>,
+        TlsWriter<'a, Socket, CipherSuite, StateContainer::State>,
     )
     where
         Socket: Clone,
-        State: SplitState,
+        StateContainer: SplitStateContainer,
     {
+        let state = state.state();
         state.set_open(self.opened);
 
         let (shared, wks, rks) = self.key_schedule.split();

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -241,7 +241,7 @@ where
         self.split_with(ManagedSplitState::new())
     }
 
-    pub fn split_with< StateContainer>(
+    pub fn split_with<StateContainer>(
         self,
         state: StateContainer,
     ) -> (

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -222,6 +222,30 @@ where
             Err(e) => Err((self.delegate, e)),
         }
     }
+
+    #[cfg(feature = "split")]
+    pub fn split(
+        self,
+    ) -> (
+        TlsReader<'a, Socket, CipherSuite>,
+        TlsWriter<'a, Socket, CipherSuite>,
+    )
+    where
+        Socket: Clone,
+    {
+        split::split(self)
+    }
+
+    #[cfg(feature = "split")]
+    pub fn unsplit(
+        reader: TlsReader<'a, Socket, CipherSuite>,
+        writer: TlsWriter<'a, Socket, CipherSuite>,
+    ) -> Self
+    where
+        Socket: Clone,
+    {
+        split::unsplit(reader, writer)
+    }
 }
 
 impl<'a, Socket, CipherSuite> Io for TlsConnection<'a, Socket, CipherSuite>
@@ -269,3 +293,239 @@ where
         TlsConnection::flush(self)
     }
 }
+
+#[cfg(feature = "split")]
+mod split {
+    use super::*;
+
+    use crate::key_schedule::{ReadKeySchedule, SharedState, WriteKeySchedule};
+    use core::sync::atomic::Ordering;
+    use std::{sync::atomic::AtomicBool, sync::Arc};
+
+    pub struct TlsReader<'a, Socket, CipherSuite>
+    where
+        Socket: Read + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        opened: Arc<AtomicBool>,
+        delegate: Socket,
+        key_schedule: ReadKeySchedule<CipherSuite>,
+        record_reader: RecordReader<'a, CipherSuite>,
+        decrypted: DecryptedBufferInfo,
+    }
+
+    impl<'a, Socket, CipherSuite> AsRef<Socket> for TlsReader<'a, Socket, CipherSuite>
+    where
+        Socket: Read + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        fn as_ref(&self) -> &Socket {
+            &self.delegate
+        }
+    }
+
+    impl<'a, Socket, CipherSuite> TlsReader<'a, Socket, CipherSuite>
+    where
+        Socket: Read + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        fn create_read_buffer(&mut self) -> ReadBuffer {
+            self.decrypted.create_read_buffer(self.record_reader.buf)
+        }
+
+        /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
+        pub fn read_buffered(&mut self) -> Result<ReadBuffer, TlsError> {
+            if self.opened.load(Ordering::Acquire) {
+                while self.decrypted.is_empty() {
+                    self.read_application_data()?;
+                }
+
+                Ok(self.create_read_buffer())
+            } else {
+                Err(TlsError::MissingHandshake)
+            }
+        }
+
+        fn read_application_data(&mut self) -> Result<(), TlsError> {
+            let buf_ptr_range = self.record_reader.buf.as_ptr_range();
+            let record = self
+                .record_reader
+                .read_blocking(&mut self.delegate, &mut self.key_schedule)?;
+
+            let mut opened = self.opened.load(Ordering::Acquire);
+            let mut handler = DecryptedReadHandler {
+                source_buffer: buf_ptr_range,
+                buffer_info: &mut self.decrypted,
+                is_open: &mut opened,
+            };
+            let result = decrypt_record(&mut self.key_schedule, record, |_key_schedule, record| {
+                handler.handle(record)
+            });
+
+            if !opened {
+                self.opened.store(false, Ordering::Release);
+            }
+            result
+        }
+    }
+
+    pub struct TlsWriter<'a, Socket, CipherSuite>
+    where
+        Socket: Write + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        opened: Arc<AtomicBool>,
+        delegate: Socket,
+        key_schedule_shared: SharedState<CipherSuite>,
+        key_schedule: WriteKeySchedule<CipherSuite>,
+        record_write_buf: &'a mut [u8],
+        write_pos: usize,
+    }
+
+    impl<'a, Socket, CipherSuite> AsRef<Socket> for TlsWriter<'a, Socket, CipherSuite>
+    where
+        Socket: Write + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        fn as_ref(&self) -> &Socket {
+            &self.delegate
+        }
+    }
+
+    impl<'a, Socket, CipherSuite> Io for TlsWriter<'a, Socket, CipherSuite>
+    where
+        Socket: Write + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        type Error = TlsError;
+    }
+
+    impl<'a, Socket, CipherSuite> Io for TlsReader<'a, Socket, CipherSuite>
+    where
+        Socket: Read + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        type Error = TlsError;
+    }
+
+    impl<'a, Socket, CipherSuite> Read for TlsReader<'a, Socket, CipherSuite>
+    where
+        Socket: Read + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            let mut buffer = self.read_buffered()?;
+
+            let len = buffer.pop_into(buf);
+            trace!("Copied {} bytes", len);
+
+            Ok(len)
+        }
+    }
+
+    impl<'a, Socket, CipherSuite> Write for TlsWriter<'a, Socket, CipherSuite>
+    where
+        Socket: Write + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            if self.opened.load(Ordering::Acquire) {
+                let max_block_size = self.record_write_buf.len() - TLS_RECORD_OVERHEAD;
+                let buffered = usize::min(buf.len(), max_block_size - self.write_pos);
+                if buffered > 0 {
+                    self.record_write_buf[self.write_pos..self.write_pos + buffered]
+                        .copy_from_slice(&buf[..buffered]);
+                    self.write_pos += buffered;
+                }
+
+                if self.write_pos == max_block_size {
+                    self.flush()?;
+                }
+
+                Ok(buffered)
+            } else {
+                Err(TlsError::MissingHandshake)
+            }
+        }
+
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            if self.write_pos > 0 {
+                let len = encode_application_data_record_in_place(
+                    self.record_write_buf,
+                    self.write_pos,
+                    &mut self.key_schedule,
+                )?;
+
+                self.delegate
+                    .write_all(&self.record_write_buf[..len])
+                    .map_err(|e| TlsError::Io(e.kind()))?;
+
+                self.key_schedule.increment_counter();
+                self.write_pos = 0;
+            }
+
+            Ok(())
+        }
+    }
+
+    pub fn split<'a, Socket, CipherSuite>(
+        connection: TlsConnection<'a, Socket, CipherSuite>,
+    ) -> (
+        TlsReader<'a, Socket, CipherSuite>,
+        TlsWriter<'a, Socket, CipherSuite>,
+    )
+    where
+        Socket: Read + Write + 'a,
+        Socket: Clone,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        let opened = Arc::new(AtomicBool::new(connection.opened));
+        let (shared, wks, rks) = connection.key_schedule.split();
+
+        let reader = TlsReader {
+            opened: opened.clone(),
+            delegate: connection.delegate.clone(),
+            key_schedule: rks,
+            record_reader: connection.record_reader,
+            decrypted: connection.decrypted,
+        };
+        let writer = TlsWriter {
+            opened,
+            delegate: connection.delegate,
+            key_schedule_shared: shared,
+            key_schedule: wks,
+            record_write_buf: connection.record_write_buf,
+            write_pos: connection.write_pos,
+        };
+
+        (reader, writer)
+    }
+
+    pub(super) fn unsplit<'a, Socket, CipherSuite>(
+        reader: TlsReader<'a, Socket, CipherSuite>,
+        writer: TlsWriter<'a, Socket, CipherSuite>,
+    ) -> TlsConnection<'a, Socket, CipherSuite>
+    where
+        Socket: Read + Write + 'a,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        debug_assert!(Arc::ptr_eq(&reader.opened, &writer.opened));
+
+        TlsConnection {
+            delegate: writer.delegate,
+            opened: writer.opened.load(Ordering::Relaxed),
+            key_schedule: KeySchedule::unsplit(
+                writer.key_schedule_shared,
+                writer.key_schedule,
+                reader.key_schedule,
+            ),
+            record_reader: reader.record_reader,
+            record_write_buf: writer.record_write_buf,
+            write_pos: writer.write_pos,
+            decrypted: reader.decrypted,
+        }
+    }
+}
+
+#[cfg(feature = "split")]
+pub use split::{TlsReader, TlsWriter};

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -461,6 +461,21 @@ where
     }
 }
 
+impl<'a, Socket, CipherSuite, State> BufRead for TlsReader<'a, Socket, CipherSuite, State>
+where
+    Socket: Read + 'a,
+    CipherSuite: TlsCipherSuite + 'static,
+    State: SplitState,
+{
+    fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+        self.read_buffered().map(|mut buf| buf.peek_all())
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.create_read_buffer().pop(amt);
+    }
+}
+
 impl<'a, Socket, CipherSuite, State> Write for TlsWriter<'a, Socket, CipherSuite, State>
 where
     Socket: Write + 'a,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -2,9 +2,11 @@ use crate::common::decrypted_buffer_info::DecryptedBufferInfo;
 use crate::common::decrypted_read_handler::DecryptedReadHandler;
 use crate::connection::*;
 use crate::key_schedule::KeySchedule;
+use crate::key_schedule::{ReadKeySchedule, SharedState, WriteKeySchedule};
 use crate::read_buffer::ReadBuffer;
 use crate::record::{ClientRecord, ClientRecordHeader};
 use crate::record_reader::RecordReader;
+use crate::split::SplitState;
 use crate::write_buffer::WriteBuffer;
 use embedded_io::blocking::BufRead;
 use embedded_io::Error as _;
@@ -15,6 +17,9 @@ use embedded_io::{
 use rand_core::{CryptoRng, RngCore};
 
 pub use crate::config::*;
+#[cfg(feature = "std")]
+pub use crate::split::ManagedSplitState;
+pub use crate::split::SplitConnectionState;
 pub use crate::TlsError;
 
 /// Type representing an async TLS connection. An instance of this type can
@@ -223,28 +228,74 @@ where
         }
     }
 
-    #[cfg(feature = "split")]
+    #[cfg(feature = "std")]
     pub fn split(
         self,
     ) -> (
-        TlsReader<'a, Socket, CipherSuite>,
-        TlsWriter<'a, Socket, CipherSuite>,
+        TlsReader<'a, Socket, CipherSuite, ManagedSplitState>,
+        TlsWriter<'a, Socket, CipherSuite, ManagedSplitState>,
     )
     where
         Socket: Clone,
     {
-        split::split(self)
+        self.split_with(ManagedSplitState::default())
     }
 
-    #[cfg(feature = "split")]
-    pub fn unsplit(
-        reader: TlsReader<'a, Socket, CipherSuite>,
-        writer: TlsWriter<'a, Socket, CipherSuite>,
+    pub fn split_with<State>(
+        self,
+        state: State,
+    ) -> (
+        TlsReader<'a, Socket, CipherSuite, State>,
+        TlsWriter<'a, Socket, CipherSuite, State>,
+    )
+    where
+        Socket: Clone,
+        State: SplitState,
+    {
+        state.set_open(self.opened);
+
+        let (shared, wks, rks) = self.key_schedule.split();
+
+        let reader = TlsReader {
+            state: state.clone(),
+            delegate: self.delegate.clone(),
+            key_schedule: rks,
+            record_reader: self.record_reader,
+            decrypted: self.decrypted,
+        };
+        let writer = TlsWriter {
+            state,
+            delegate: self.delegate,
+            key_schedule_shared: shared,
+            key_schedule: wks,
+            record_write_buf: self.record_write_buf,
+        };
+
+        (reader, writer)
+    }
+
+    pub fn unsplit<State>(
+        reader: TlsReader<'a, Socket, CipherSuite, State>,
+        writer: TlsWriter<'a, Socket, CipherSuite, State>,
     ) -> Self
     where
         Socket: Clone,
+        State: SplitState,
     {
-        split::unsplit(reader, writer)
+        debug_assert!(reader.state.same(&writer.state));
+
+        TlsConnection {
+            delegate: writer.delegate,
+            opened: writer.state.is_open(),
+            key_schedule: KeySchedule::unsplit(
+                writer.key_schedule_shared,
+                writer.key_schedule,
+                reader.key_schedule,
+            ),
+            record_reader: reader.record_reader,
+            record_write_buf: writer.record_write_buf,
+            decrypted: reader.decrypted,
+        }
     }
 }
 
@@ -294,238 +345,162 @@ where
     }
 }
 
-#[cfg(feature = "split")]
-mod split {
-    use super::*;
+pub struct TlsReader<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    state: State,
+    delegate: Socket,
+    key_schedule: ReadKeySchedule<CipherSuite>,
+    record_reader: RecordReader<'a, CipherSuite>,
+    decrypted: DecryptedBufferInfo,
+}
 
-    use crate::key_schedule::{ReadKeySchedule, SharedState, WriteKeySchedule};
-    use core::sync::atomic::Ordering;
-    use std::{sync::atomic::AtomicBool, sync::Arc};
-
-    pub struct TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: Read + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        opened: Arc<AtomicBool>,
-        delegate: Socket,
-        key_schedule: ReadKeySchedule<CipherSuite>,
-        record_reader: RecordReader<'a, CipherSuite>,
-        decrypted: DecryptedBufferInfo,
-    }
-
-    impl<'a, Socket, CipherSuite> AsRef<Socket> for TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: Read + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        fn as_ref(&self) -> &Socket {
-            &self.delegate
-        }
-    }
-
-    impl<'a, Socket, CipherSuite> TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: Read + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        fn create_read_buffer(&mut self) -> ReadBuffer {
-            self.decrypted.create_read_buffer(self.record_reader.buf)
-        }
-
-        /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
-        pub fn read_buffered(&mut self) -> Result<ReadBuffer, TlsError> {
-            if self.opened.load(Ordering::Acquire) {
-                while self.decrypted.is_empty() {
-                    self.read_application_data()?;
-                }
-
-                Ok(self.create_read_buffer())
-            } else {
-                Err(TlsError::MissingHandshake)
-            }
-        }
-
-        fn read_application_data(&mut self) -> Result<(), TlsError> {
-            let buf_ptr_range = self.record_reader.buf.as_ptr_range();
-            let record = self
-                .record_reader
-                .read_blocking(&mut self.delegate, &mut self.key_schedule)?;
-
-            let mut opened = self.opened.load(Ordering::Acquire);
-            let mut handler = DecryptedReadHandler {
-                source_buffer: buf_ptr_range,
-                buffer_info: &mut self.decrypted,
-                is_open: &mut opened,
-            };
-            let result = decrypt_record(&mut self.key_schedule, record, |_key_schedule, record| {
-                handler.handle(record)
-            });
-
-            if !opened {
-                self.opened.store(false, Ordering::Release);
-            }
-            result
-        }
-    }
-
-    pub struct TlsWriter<'a, Socket, CipherSuite>
-    where
-        Socket: Write + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        opened: Arc<AtomicBool>,
-        delegate: Socket,
-        key_schedule_shared: SharedState<CipherSuite>,
-        key_schedule: WriteKeySchedule<CipherSuite>,
-        record_write_buf: &'a mut [u8],
-        write_pos: usize,
-    }
-
-    impl<'a, Socket, CipherSuite> AsRef<Socket> for TlsWriter<'a, Socket, CipherSuite>
-    where
-        Socket: Write + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        fn as_ref(&self) -> &Socket {
-            &self.delegate
-        }
-    }
-
-    impl<'a, Socket, CipherSuite> Io for TlsWriter<'a, Socket, CipherSuite>
-    where
-        Socket: Write + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        type Error = TlsError;
-    }
-
-    impl<'a, Socket, CipherSuite> Io for TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: Read + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        type Error = TlsError;
-    }
-
-    impl<'a, Socket, CipherSuite> Read for TlsReader<'a, Socket, CipherSuite>
-    where
-        Socket: Read + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-            let mut buffer = self.read_buffered()?;
-
-            let len = buffer.pop_into(buf);
-            trace!("Copied {} bytes", len);
-
-            Ok(len)
-        }
-    }
-
-    impl<'a, Socket, CipherSuite> Write for TlsWriter<'a, Socket, CipherSuite>
-    where
-        Socket: Write + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-            if self.opened.load(Ordering::Acquire) {
-                let max_block_size = self.record_write_buf.len() - TLS_RECORD_OVERHEAD;
-                let buffered = usize::min(buf.len(), max_block_size - self.write_pos);
-                if buffered > 0 {
-                    self.record_write_buf[self.write_pos..self.write_pos + buffered]
-                        .copy_from_slice(&buf[..buffered]);
-                    self.write_pos += buffered;
-                }
-
-                if self.write_pos == max_block_size {
-                    self.flush()?;
-                }
-
-                Ok(buffered)
-            } else {
-                Err(TlsError::MissingHandshake)
-            }
-        }
-
-        fn flush(&mut self) -> Result<(), Self::Error> {
-            if self.write_pos > 0 {
-                let len = encode_application_data_record_in_place(
-                    self.record_write_buf,
-                    self.write_pos,
-                    &mut self.key_schedule,
-                )?;
-
-                self.delegate
-                    .write_all(&self.record_write_buf[..len])
-                    .map_err(|e| TlsError::Io(e.kind()))?;
-
-                self.key_schedule.increment_counter();
-                self.write_pos = 0;
-            }
-
-            Ok(())
-        }
-    }
-
-    pub fn split<'a, Socket, CipherSuite>(
-        connection: TlsConnection<'a, Socket, CipherSuite>,
-    ) -> (
-        TlsReader<'a, Socket, CipherSuite>,
-        TlsWriter<'a, Socket, CipherSuite>,
-    )
-    where
-        Socket: Read + Write + 'a,
-        Socket: Clone,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        let opened = Arc::new(AtomicBool::new(connection.opened));
-        let (shared, wks, rks) = connection.key_schedule.split();
-
-        let reader = TlsReader {
-            opened: opened.clone(),
-            delegate: connection.delegate.clone(),
-            key_schedule: rks,
-            record_reader: connection.record_reader,
-            decrypted: connection.decrypted,
-        };
-        let writer = TlsWriter {
-            opened,
-            delegate: connection.delegate,
-            key_schedule_shared: shared,
-            key_schedule: wks,
-            record_write_buf: connection.record_write_buf,
-            write_pos: connection.write_pos,
-        };
-
-        (reader, writer)
-    }
-
-    pub(super) fn unsplit<'a, Socket, CipherSuite>(
-        reader: TlsReader<'a, Socket, CipherSuite>,
-        writer: TlsWriter<'a, Socket, CipherSuite>,
-    ) -> TlsConnection<'a, Socket, CipherSuite>
-    where
-        Socket: Read + Write + 'a,
-        CipherSuite: TlsCipherSuite + 'static,
-    {
-        debug_assert!(Arc::ptr_eq(&reader.opened, &writer.opened));
-
-        TlsConnection {
-            delegate: writer.delegate,
-            opened: writer.opened.load(Ordering::Relaxed),
-            key_schedule: KeySchedule::unsplit(
-                writer.key_schedule_shared,
-                writer.key_schedule,
-                reader.key_schedule,
-            ),
-            record_reader: reader.record_reader,
-            record_write_buf: writer.record_write_buf,
-            write_pos: writer.write_pos,
-            decrypted: reader.decrypted,
-        }
+impl<'a, Socket, CipherSuite, State> AsRef<Socket> for TlsReader<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    fn as_ref(&self) -> &Socket {
+        &self.delegate
     }
 }
 
-#[cfg(feature = "split")]
-pub use split::{TlsReader, TlsWriter};
+impl<'a, Socket, CipherSuite, State> TlsReader<'a, Socket, CipherSuite, State>
+where
+    Socket: Read + 'a,
+    CipherSuite: TlsCipherSuite + 'static,
+    State: SplitState,
+{
+    fn create_read_buffer(&mut self) -> ReadBuffer {
+        self.decrypted.create_read_buffer(self.record_reader.buf)
+    }
+
+    /// Reads buffered data. If nothing is in memory, it'll wait for a TLS record and process it.
+    pub fn read_buffered(&mut self) -> Result<ReadBuffer, TlsError> {
+        if self.state.is_open() {
+            while self.decrypted.is_empty() {
+                self.read_application_data()?;
+            }
+
+            Ok(self.create_read_buffer())
+        } else {
+            Err(TlsError::MissingHandshake)
+        }
+    }
+
+    fn read_application_data(&mut self) -> Result<(), TlsError> {
+        let buf_ptr_range = self.record_reader.buf.as_ptr_range();
+        let record = self
+            .record_reader
+            .read_blocking(&mut self.delegate, &mut self.key_schedule)?;
+
+        let mut opened = self.state.is_open();
+        let mut handler = DecryptedReadHandler {
+            source_buffer: buf_ptr_range,
+            buffer_info: &mut self.decrypted,
+            is_open: &mut opened,
+        };
+        let result = decrypt_record(&mut self.key_schedule, record, |_key_schedule, record| {
+            handler.handle(record)
+        });
+
+        if !opened {
+            self.state.set_open(false);
+        }
+        result
+    }
+}
+
+pub struct TlsWriter<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    state: State,
+    delegate: Socket,
+    key_schedule_shared: SharedState<CipherSuite>,
+    key_schedule: WriteKeySchedule<CipherSuite>,
+    record_write_buf: WriteBuffer<'a>,
+}
+
+impl<'a, Socket, CipherSuite, State> AsRef<Socket> for TlsWriter<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    fn as_ref(&self) -> &Socket {
+        &self.delegate
+    }
+}
+
+impl<'a, Socket, CipherSuite, State> Io for TlsWriter<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    type Error = TlsError;
+}
+
+impl<'a, Socket, CipherSuite, State> Io for TlsReader<'a, Socket, CipherSuite, State>
+where
+    CipherSuite: TlsCipherSuite + 'static,
+{
+    type Error = TlsError;
+}
+
+impl<'a, Socket, CipherSuite, State> Read for TlsReader<'a, Socket, CipherSuite, State>
+where
+    Socket: Read + 'a,
+    CipherSuite: TlsCipherSuite + 'static,
+    State: SplitState,
+{
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let mut buffer = self.read_buffered()?;
+
+        let len = buffer.pop_into(buf);
+        trace!("Copied {} bytes", len);
+
+        Ok(len)
+    }
+}
+
+impl<'a, Socket, CipherSuite, State> Write for TlsWriter<'a, Socket, CipherSuite, State>
+where
+    Socket: Write + 'a,
+    CipherSuite: TlsCipherSuite + 'static,
+    State: SplitState,
+{
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        if self.state.is_open() {
+            if !self
+                .record_write_buf
+                .contains(ClientRecordHeader::ApplicationData)
+            {
+                self.flush()?;
+                self.record_write_buf
+                    .start_record(ClientRecordHeader::ApplicationData)?;
+            }
+
+            let buffered = self.record_write_buf.append(buf);
+
+            if self.record_write_buf.is_full() {
+                self.flush()?;
+            }
+
+            Ok(buffered)
+        } else {
+            Err(TlsError::MissingHandshake)
+        }
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        if !self.record_write_buf.is_empty() {
+            let slice = self.record_write_buf.close_record(&mut self.key_schedule)?;
+
+            self.delegate
+                .write_all(slice)
+                .map_err(|e| TlsError::Io(e.kind()))?;
+
+            self.key_schedule.increment_counter();
+        }
+
+        Ok(())
+    }
+}

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -200,7 +200,11 @@ where
     }
 
     fn empty_hash() -> Self {
-        Self::Hash(CipherSuite::Hash::new().chain_update([]).finalize())
+        Self::Hash(
+            <CipherSuite::Hash as Digest>::new()
+                .chain_update([])
+                .finalize(),
+        )
     }
 }
 
@@ -226,7 +230,7 @@ where
             },
             server_state: ReadKeySchedule {
                 state: KeyScheduleState::new(),
-                transcript_hash: CipherSuite::Hash::new(),
+                transcript_hash: <CipherSuite::Hash as Digest>::new(),
             },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub mod read_buffer;
 mod record;
 mod record_reader;
 mod signature_schemes;
+mod split;
 mod supported_versions;
 mod write_buffer;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 #![allow(non_snake_case)]
 #![cfg_attr(feature = "async", allow(incomplete_features))]
@@ -140,7 +140,6 @@ impl embedded_io::Error for TlsError {
 
 #[cfg(feature = "std")]
 mod stdlib {
-    extern crate std;
     use crate::config::TlsClock;
 
     use std::time::SystemTime;

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,0 +1,66 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+
+pub trait SplitState: Clone {
+    fn same(&self, other: &Self) -> bool;
+    fn is_open(&self) -> bool;
+    fn set_open(&self, open: bool);
+}
+
+pub struct SplitConnectionState {
+    is_open: AtomicBool,
+}
+
+impl Default for SplitConnectionState {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            is_open: AtomicBool::new(true),
+        }
+    }
+}
+
+impl SplitState for &SplitConnectionState {
+    fn is_open(&self) -> bool {
+        self.is_open.load(Ordering::Acquire)
+    }
+
+    fn set_open(&self, open: bool) {
+        self.is_open.store(open, Ordering::Release);
+    }
+
+    fn same(&self, other: &Self) -> bool {
+        core::ptr::eq(self, other)
+    }
+}
+
+#[cfg(feature = "std")]
+pub use stdlib::ManagedSplitState;
+
+#[cfg(feature = "std")]
+mod stdlib {
+    use super::*;
+    use std::sync::Arc;
+
+    #[derive(Clone)]
+    pub struct ManagedSplitState(Arc<SplitConnectionState>);
+    impl Default for ManagedSplitState {
+        #[inline]
+        fn default() -> Self {
+            Self(Arc::new(SplitConnectionState::default()))
+        }
+    }
+
+    impl SplitState for ManagedSplitState {
+        fn is_open(&self) -> bool {
+            self.0.as_ref().is_open()
+        }
+
+        fn set_open(&self, open: bool) {
+            self.0.as_ref().set_open(open)
+        }
+
+        fn same(&self, other: &Self) -> bool {
+            Arc::ptr_eq(&self.0, &other.0)
+        }
+    }
+}

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicBool, Ordering};
+use atomic_polyfill::{AtomicBool, Ordering};
 
 pub trait SplitState: Clone {
     fn same(&self, other: &Self) -> bool;

--- a/src/split.rs
+++ b/src/split.rs
@@ -43,7 +43,7 @@ impl SplitState for &SplitConnectionState {
     }
 
     fn same(&self, other: &Self) -> bool {
-        core::ptr::eq(self, other)
+        core::ptr::eq(*self, *other)
     }
 }
 

--- a/tests/split_test.rs
+++ b/tests/split_test.rs
@@ -1,0 +1,159 @@
+#![macro_use]
+#![allow(incomplete_features)]
+#![feature(async_fn_in_trait)]
+#![feature(impl_trait_projections)]
+use embedded_io::adapters::FromStd;
+use embedded_io::blocking::{Read, Write};
+use rand_core::OsRng;
+use std::net::{SocketAddr, TcpStream};
+use std::sync::Once;
+
+mod tlsserver;
+
+static INIT: Once = Once::new();
+static mut ADDR: Option<SocketAddr> = None;
+
+fn setup() -> SocketAddr {
+    use mio::net::TcpListener;
+    INIT.call_once(|| {
+        env_logger::init();
+
+        let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+
+        let listener = TcpListener::bind(addr).expect("cannot listen on port");
+        let addr = listener
+            .local_addr()
+            .expect("error retrieving socket address");
+
+        std::thread::spawn(move || {
+            tlsserver::run(listener);
+        });
+        unsafe { ADDR.replace(addr) };
+    });
+    unsafe { ADDR.unwrap() }
+}
+
+pub struct Clonable<T: ?Sized>(std::sync::Arc<T>);
+
+impl<T: ?Sized> Clone for Clonable<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl embedded_io::Io for Clonable<TcpStream> {
+    type Error = std::io::Error;
+}
+
+impl embedded_io::blocking::Read for Clonable<TcpStream> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let mut stream = FromStd::new(self.0.as_ref());
+        stream.read(buf)
+    }
+}
+
+impl embedded_io::blocking::Write for Clonable<TcpStream> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        let mut stream = FromStd::new(self.0.as_ref());
+        stream.write(buf)
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        let mut stream = FromStd::new(self.0.as_ref());
+        stream.flush()
+    }
+}
+
+#[test]
+fn test_blocking_borrowed() {
+    use embedded_tls::blocking::*;
+    use std::net::TcpStream;
+    use std::sync::Arc;
+    let addr = setup();
+    let pem = include_str!("data/ca-cert.pem");
+    let der = pem_parser::pem_to_der(pem);
+
+    let stream = TcpStream::connect(addr).expect("error connecting to server");
+
+    log::info!("Connected");
+    let mut read_record_buffer = [0; 16384];
+    let mut write_record_buffer = [0; 16384];
+    let config = TlsConfig::new()
+        .with_ca(Certificate::X509(&der[..]))
+        .with_server_name("localhost");
+
+    let mut tls: TlsConnection<Clonable<TcpStream>, Aes128GcmSha256> = TlsConnection::new(
+        Clonable(Arc::new(stream)),
+        &mut read_record_buffer,
+        &mut write_record_buffer,
+    );
+
+    tls.open::<OsRng, NoVerify>(TlsContext::new(&config, &mut OsRng))
+        .expect("error establishing TLS connection");
+
+    let mut state = SplitConnectionState::default();
+    let (mut reader, mut writer) = tls.split_with(&mut state);
+
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            let mut buffer = [0; 4];
+            reader.read_exact(&mut buffer).expect("Failed to read data");
+        });
+        scope.spawn(|| {
+            writer.write(b"ping").expect("Failed to write data");
+            writer.flush().expect("Failed to flush");
+        });
+    });
+
+    let tls = TlsConnection::unsplit(reader, writer);
+
+    tls.close()
+        .map_err(|(_, e)| e)
+        .expect("error closing session");
+}
+
+#[test]
+fn test_blocking_managed() {
+    use embedded_tls::blocking::*;
+    use std::net::TcpStream;
+    use std::sync::Arc;
+    let addr = setup();
+    let pem = include_str!("data/ca-cert.pem");
+    let der = pem_parser::pem_to_der(pem);
+
+    let stream = TcpStream::connect(addr).expect("error connecting to server");
+
+    log::info!("Connected");
+    let mut read_record_buffer = [0; 16384];
+    let mut write_record_buffer = [0; 16384];
+    let config = TlsConfig::new()
+        .with_ca(Certificate::X509(&der[..]))
+        .with_server_name("localhost");
+
+    let mut tls: TlsConnection<Clonable<TcpStream>, Aes128GcmSha256> = TlsConnection::new(
+        Clonable(Arc::new(stream)),
+        &mut read_record_buffer,
+        &mut write_record_buffer,
+    );
+
+    tls.open::<OsRng, NoVerify>(TlsContext::new(&config, &mut OsRng))
+        .expect("error establishing TLS connection");
+
+    let (mut reader, mut writer) = tls.split();
+
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            let mut buffer = [0; 4];
+            reader.read_exact(&mut buffer).expect("Failed to read data");
+        });
+        scope.spawn(|| {
+            writer.write(b"ping").expect("Failed to write data");
+            writer.flush().expect("Failed to flush");
+        });
+    });
+
+    let tls = TlsConnection::unsplit(reader, writer);
+
+    tls.close()
+        .map_err(|(_, e)| e)
+        .expect("error closing session");
+}


### PR DESCRIPTION
There are two ways to split a connection:
 - using `std`, calling `.split()` will create a heap-allocated shared state object
 - calling `.split_with(state)` where users can pass a reference to a `SplitConnectionState` instance