### PR TITLE
Use minimal buffer for label expansion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ aes-gcm = { version = "0.10.1", default-features = false, features = ["aes"] }
 digest = { version = "0.10.3", default-features = false, features = ["core-api"] }
 typenum = { version = "1.15.0", default-features = false }
 heapless = { version = "0.7", default-features = false }
+heapless_typenum = { package = "heapless", version = "0.6", default-features = false }
 embedded-io = "0.4"
 generic-array = { version = "0.14", default-features = false }
 #webpki = { version = "0.22.0", default-features = false }

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -2,14 +2,14 @@ use crate::handshake::binder::PskBinder;
 use crate::handshake::finished::Finished;
 use crate::{config::TlsCipherSuite, TlsError};
 use digest::generic_array::ArrayLength;
-use heapless::Vec;
-use hmac::digest::OutputSizeUser;
+use digest::OutputSizeUser;
 use hmac::{Mac, SimpleHmac};
 use sha2::digest::generic_array::{typenum::Unsigned, GenericArray};
 use sha2::Digest;
 
 pub type HashOutputSize<CipherSuite> =
     <<CipherSuite as TlsCipherSuite>::Hash as OutputSizeUser>::OutputSize;
+pub type LabelBufferSize<CipherSuite> = <CipherSuite as TlsCipherSuite>::LabelBufferSize;
 
 pub type IvArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::IvLen>;
 pub type KeyArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::KeyLen>;
@@ -296,7 +296,7 @@ where
         hkdf: &Hkdf<CipherSuite>,
     ) -> Result<GenericArray<u8, N>, TlsError> {
         //info!("make label {:?} {}", label, len);
-        let mut hkdf_label = Vec::<u8, 512>::new();
+        let mut hkdf_label = heapless_typenum::Vec::<u8, LabelBufferSize<CipherSuite>>::new();
         hkdf_label
             .extend_from_slice(&N::to_u16().to_be_bytes())
             .map_err(|_| TlsError::InternalError)?;


### PR DESCRIPTION
Instead of a hardcoded 512 byte vector, use a buffer size appropriate for the actual CipherSuite instance.

I have made a few assumptions here but the 512 buffer was also an assumption, I assume :) If only I didn't need to use typenum here...