### PR TITLE
Clean up and fix CryptoBuffer u24 encode issue

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -50,7 +50,7 @@ impl<'b> CryptoBuffer<'b> {
 
     pub fn push_u24(&mut self, num: u32) -> Result<(), TlsError> {
         let data = num.to_be_bytes();
-        self.extend_from_slice(&[data[0], data[1], data[2]])
+        self.extend_from_slice(&[data[1], data[2], data[3]])
     }
 
     pub fn push_u32(&mut self, num: u32) -> Result<(), TlsError> {
@@ -190,11 +190,19 @@ mod test {
 
     #[test]
     fn encode() {
-        let mut buf = [0; 4];
-        let mut c = CryptoBuffer::wrap(&mut buf);
-        c.push_u24(1024).unwrap();
-        let decoded = u32::from_be_bytes(buf);
-        assert_eq!(1024, decoded);
+        let mut buf1 = [0; 4];
+        let mut c = CryptoBuffer::wrap(&mut buf1);
+        c.push_u24(1027).unwrap();
+
+        let mut buf2 = [0; 4];
+        let mut c = CryptoBuffer::wrap(&mut buf2);
+        c.push_u24(0).unwrap();
+        c.set_u24(0, 1027).unwrap();
+
+        assert_eq!(buf1, buf2);
+
+        let decoded = u32::from_be_bytes([0, buf1[0], buf1[1], buf1[2]]);
+        assert_eq!(1027, decoded);
     }
 
     #[test]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -160,6 +160,36 @@ impl<'b> CryptoBuffer<'b> {
             offset,
         }
     }
+
+    pub fn with_u8_length<R>(
+        &mut self,
+        op: impl FnOnce(&mut Self) -> Result<R, TlsError>,
+    ) -> Result<R, TlsError> {
+        let len_pos = self.len;
+        self.push(0)?;
+
+        let r = op(self)?;
+
+        let len = (self.len() - len_pos) as u8 - 1;
+        self.set(len_pos, len)?;
+
+        Ok(r)
+    }
+
+    pub fn with_u16_length<R>(
+        &mut self,
+        op: impl FnOnce(&mut Self) -> Result<R, TlsError>,
+    ) -> Result<R, TlsError> {
+        let len_pos = self.len;
+        self.push_u16(0)?;
+
+        let r = op(self)?;
+
+        let len = (self.len() - len_pos) as u16 - 2;
+        self.set_u16(len_pos, len)?;
+
+        Ok(r)
+    }
 }
 
 impl<'b> AsRef<[u8]> for CryptoBuffer<'b> {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -191,14 +191,16 @@ where
                 let binders_len =
                     identities.len() * (1 + HashOutputSize::<CipherSuite>::to_usize());
 
+                let binders_pos = range.end - binders_len;
+
                 // NOTE: Exclude the binders_len itself from the digest
                 Digest::update(
                     read_key_schedule.transcript_hash(),
-                    &tx_buf[range.start..range.end - binders_len - 2],
+                    &tx_buf[range.start..binders_pos - 2],
                 );
 
                 // Append after the client hello data. Sizes have already been set.
-                let mut buf = CryptoBuffer::wrap(&mut tx_buf[range.end - binders_len..]);
+                let mut buf = CryptoBuffer::wrap(&mut tx_buf[binders_pos..]);
                 // Create a binder and encode for each identity
                 for _id in identities {
                     let binder = write_key_schedule
@@ -208,7 +210,7 @@ where
 
                 Digest::update(
                     read_key_schedule.transcript_hash(),
-                    &tx_buf[range.end - binders_len - 2..range.end],
+                    &tx_buf[binders_pos - 2..range.end],
                 );
             } else {
                 Digest::update(read_key_schedule.transcript_hash(), &tx_buf[range]);

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -106,8 +106,8 @@ pub enum PskKeyExchangeMode {
 }
 
 impl ClientExtension<'_> {
-    pub fn extension_type(&self) -> [u8; 2] {
-        (match self {
+    pub fn extension_type(&self) -> ExtensionType {
+        match self {
             ClientExtension::ServerName { .. } => ExtensionType::ServerName,
             ClientExtension::SupportedVersions { .. } => ExtensionType::SupportedVersions,
             ClientExtension::SignatureAlgorithms { .. } => ExtensionType::SignatureAlgorithms,
@@ -119,29 +119,27 @@ impl ClientExtension<'_> {
             ClientExtension::PskKeyExchangeModes { .. } => ExtensionType::PskKeyExchangeModes,
             ClientExtension::PreSharedKey { .. } => ExtensionType::PreSharedKey,
             ClientExtension::MaxFragmentLength(_) => ExtensionType::MaxFragmentLength,
-        } as u16)
-            .to_be_bytes()
+        }
     }
 
     pub(crate) fn encode(&self, buf: &mut CryptoBuffer) -> Result<(), TlsError> {
-        buf.extend_from_slice(&self.extension_type())
+        buf.push_u16(self.extension_type() as u16)
             .map_err(|_| TlsError::EncodeError)?;
         let extension_length_marker = buf.len();
         //info!("marker at {}", extension_length_marker);
-        buf.push(0).map_err(|_| TlsError::EncodeError)?;
-        buf.push(0).map_err(|_| TlsError::EncodeError)?;
+        buf.push_u16(0).map_err(|_| TlsError::EncodeError)?;
 
         match self {
             ClientExtension::ServerName { server_name } => {
                 //info!("server name ext");
-                let sni_size: u16 = (server_name.as_bytes().len() + 3) as u16;
+                let sni_size = (server_name.as_bytes().len() + 3) as u16;
 
-                buf.extend_from_slice(&sni_size.to_be_bytes())
-                    .map_err(|_| TlsError::EncodeError)?;
+                buf.push_u16(sni_size).map_err(|_| TlsError::EncodeError)?;
 
                 // Type host
-                buf.push(0).map_err(|_| TlsError::EncodeError)?;
-                buf.extend_from_slice(&(server_name.as_bytes().len() as u16).to_be_bytes())
+                const HOST: u8 = 0;
+                buf.push(HOST).map_err(|_| TlsError::EncodeError)?;
+                buf.push_u16(server_name.as_bytes().len() as u16)
                     .map_err(|_| TlsError::EncodeError)?;
                 buf.extend_from_slice(server_name.as_bytes())
                     .map_err(|_| TlsError::EncodeError)?;
@@ -157,57 +155,49 @@ impl ClientExtension<'_> {
                 //info!("supported versions ext");
                 buf.push(versions.len() as u8 * 2)
                     .map_err(|_| TlsError::EncodeError)?;
-                for v in versions {
-                    buf.extend_from_slice(&v.to_be_bytes())
-                        .map_err(|_| TlsError::EncodeError)?;
+                for &v in versions {
+                    buf.push_u16(v).map_err(|_| TlsError::EncodeError)?;
                 }
             }
             ClientExtension::SignatureAlgorithms {
                 supported_signature_algorithms,
             } => {
                 //info!("supported sig algo ext");
-                buf.extend_from_slice(
-                    &(supported_signature_algorithms.len() as u16 * 2).to_be_bytes(),
-                )
-                .map_err(|_| TlsError::EncodeError)?;
+                buf.push_u16(supported_signature_algorithms.len() as u16 * 2)
+                    .map_err(|_| TlsError::EncodeError)?;
 
-                for a in supported_signature_algorithms {
-                    buf.extend_from_slice(&(*a as u16).to_be_bytes())
-                        .map_err(|_| TlsError::EncodeError)?;
+                for &a in supported_signature_algorithms {
+                    buf.push_u16(a as u16).map_err(|_| TlsError::EncodeError)?;
                 }
             }
             ClientExtension::SignatureAlgorithmsCert {
                 supported_signature_algorithms,
             } => {
                 //info!("supported sig algo cert ext");
-                buf.extend_from_slice(
-                    &(supported_signature_algorithms.len() as u16 * 2).to_be_bytes(),
-                )
-                .map_err(|_| TlsError::EncodeError)?;
+                buf.push_u16(supported_signature_algorithms.len() as u16 * 2)
+                    .map_err(|_| TlsError::EncodeError)?;
 
-                for a in supported_signature_algorithms {
-                    buf.extend_from_slice(&(*a as u16).to_be_bytes())
-                        .map_err(|_| TlsError::EncodeError)?;
+                for &a in supported_signature_algorithms {
+                    buf.push_u16(a as u16).map_err(|_| TlsError::EncodeError)?;
                 }
             }
             ClientExtension::SupportedGroups { supported_groups } => {
                 //info!("supported groups ext");
-                buf.extend_from_slice(&(supported_groups.len() as u16 * 2).to_be_bytes())
+                buf.push_u16(supported_groups.len() as u16 * 2)
                     .map_err(|_| TlsError::EncodeError)?;
 
-                for g in supported_groups {
-                    buf.extend_from_slice(&(*g as u16).to_be_bytes())
-                        .map_err(|_| TlsError::EncodeError)?;
+                for &g in supported_groups {
+                    buf.push_u16(g as u16).map_err(|_| TlsError::EncodeError)?;
                 }
             }
             ClientExtension::KeyShare { group, opaque } => {
                 //info!("key_share ext");
-                buf.extend_from_slice(&(2 + 2 + opaque.len() as u16).to_be_bytes())
+                buf.push_u16(2 + 2 + opaque.len() as u16)
                     .map_err(|_| TlsError::EncodeError)?;
                 // one key-share
-                buf.extend_from_slice(&(*group as u16).to_be_bytes())
+                buf.push_u16(*group as u16)
                     .map_err(|_| TlsError::EncodeError)?;
-                buf.extend_from_slice(&(opaque.len() as u16).to_be_bytes())
+                buf.push_u16(opaque.len() as u16)
                     .map_err(|_| TlsError::EncodeError)?;
                 buf.extend_from_slice(opaque.as_ref())
                     .map_err(|_| TlsError::EncodeError)?;
@@ -218,23 +208,22 @@ impl ClientExtension<'_> {
             } => {
                 // Each identity entry is of length identity.len() + u32 (for the ticket age)
                 let identities_len: usize = identities.iter().map(|i| i.len() + 2 + 4).sum();
-                buf.extend_from_slice(&(identities_len as u16).to_be_bytes())
+                buf.push_u16(identities_len as u16)
                     .map_err(|_| TlsError::EncodeError)?;
                 for identity in identities {
-                    buf.extend_from_slice(&(identity.len() as u16).to_be_bytes())
+                    buf.push_u16(identity.len() as u16)
                         .map_err(|_| TlsError::EncodeError)?;
 
                     buf.extend_from_slice(identity)
                         .map_err(|_| TlsError::EncodeError)?;
 
                     // NOTE: No support for ticket age, set to 0 as recommended by RFC
-                    buf.extend_from_slice(&0u32.to_be_bytes())
-                        .map_err(|_| TlsError::EncodeError)?;
+                    buf.push_u32(0u32).map_err(|_| TlsError::EncodeError)?;
                 }
 
                 // NOTE: We encode binders later after computing the transcript.
                 let binders_len = (1 + hash_size) * identities.len();
-                buf.extend_from_slice(&(binders_len as u16).to_be_bytes())
+                buf.push_u16(binders_len as u16)
                     .map_err(|_| TlsError::EncodeError)?;
 
                 for _ in 0..binders_len {
@@ -248,15 +237,11 @@ impl ClientExtension<'_> {
         }
 
         //info!("tail at {}", buf.len());
-        let extension_length = (buf.len() as u16 - extension_length_marker as u16) - 2;
+        let extension_length = (buf.len() - extension_length_marker) as u16 - 2;
         //info!("len: {}", extension_length);
-        buf.set(extension_length_marker, extension_length.to_be_bytes()[0])
-            .map_err(|_| TlsError::EncodeError)?;
-        buf.set(
-            extension_length_marker + 1,
-            extension_length.to_be_bytes()[1],
-        )
-        .map_err(|_| TlsError::EncodeError)?;
+
+        buf.set_u16(extension_length_marker, extension_length)?;
+
         Ok(())
     }
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -125,123 +125,109 @@ impl ClientExtension<'_> {
     pub(crate) fn encode(&self, buf: &mut CryptoBuffer) -> Result<(), TlsError> {
         buf.push_u16(self.extension_type() as u16)
             .map_err(|_| TlsError::EncodeError)?;
-        let extension_length_marker = buf.len();
-        //info!("marker at {}", extension_length_marker);
-        buf.push_u16(0).map_err(|_| TlsError::EncodeError)?;
 
-        match self {
-            ClientExtension::ServerName { server_name } => {
-                //info!("server name ext");
-                let sni_size = (server_name.as_bytes().len() + 3) as u16;
+        buf.with_u16_length(|buf| {
+            match self {
+                ClientExtension::ServerName { server_name } => {
+                    //info!("server name ext");
+                    buf.with_u16_length(|buf| {
+                        const NAME_TYPE_HOST: u8 = 0;
+                        buf.push(NAME_TYPE_HOST)
+                            .map_err(|_| TlsError::EncodeError)?;
 
-                buf.push_u16(sni_size).map_err(|_| TlsError::EncodeError)?;
-
-                // Type host
-                const HOST: u8 = 0;
-                buf.push(HOST).map_err(|_| TlsError::EncodeError)?;
-                buf.push_u16(server_name.as_bytes().len() as u16)
-                    .map_err(|_| TlsError::EncodeError)?;
-                buf.extend_from_slice(server_name.as_bytes())
-                    .map_err(|_| TlsError::EncodeError)?;
-            }
-            ClientExtension::PskKeyExchangeModes { modes } => {
-                buf.push(modes.len() as u8)
-                    .map_err(|_| TlsError::EncodeError)?;
-                for mode in modes {
-                    buf.push(*mode as u8).map_err(|_| TlsError::EncodeError)?;
+                        buf.with_u16_length(|buf| buf.extend_from_slice(server_name.as_bytes()))
+                            .map_err(|_| TlsError::EncodeError)
+                    })
                 }
-            }
-            ClientExtension::SupportedVersions { versions } => {
-                //info!("supported versions ext");
-                buf.push(versions.len() as u8 * 2)
-                    .map_err(|_| TlsError::EncodeError)?;
-                for &v in versions {
-                    buf.push_u16(v).map_err(|_| TlsError::EncodeError)?;
+                ClientExtension::PskKeyExchangeModes { modes } => buf.with_u8_length(|buf| {
+                    for mode in modes {
+                        buf.push(*mode as u8).map_err(|_| TlsError::EncodeError)?;
+                    }
+                    Ok(())
+                }),
+                ClientExtension::SupportedVersions { versions } => {
+                    //info!("supported versions ext");
+                    buf.with_u8_length(|buf| {
+                        for &v in versions {
+                            buf.push_u16(v).map_err(|_| TlsError::EncodeError)?;
+                        }
+                        Ok(())
+                    })
                 }
-            }
-            ClientExtension::SignatureAlgorithms {
-                supported_signature_algorithms,
-            } => {
-                //info!("supported sig algo ext");
-                buf.push_u16(supported_signature_algorithms.len() as u16 * 2)
+                ClientExtension::SignatureAlgorithms {
+                    supported_signature_algorithms,
+                } => {
+                    //info!("supported sig algo ext");
+                    buf.with_u16_length(|buf| {
+                        for &a in supported_signature_algorithms {
+                            buf.push_u16(a as u16).map_err(|_| TlsError::EncodeError)?;
+                        }
+                        Ok(())
+                    })
+                }
+                ClientExtension::SignatureAlgorithmsCert {
+                    supported_signature_algorithms,
+                } => {
+                    //info!("supported sig algo cert ext");
+                    buf.with_u16_length(|buf| {
+                        for &a in supported_signature_algorithms {
+                            buf.push_u16(a as u16).map_err(|_| TlsError::EncodeError)?;
+                        }
+                        Ok(())
+                    })
+                }
+                ClientExtension::SupportedGroups { supported_groups } => {
+                    //info!("supported groups ext");
+                    buf.with_u16_length(|buf| {
+                        for &g in supported_groups {
+                            buf.push_u16(g as u16).map_err(|_| TlsError::EncodeError)?;
+                        }
+                        Ok(())
+                    })
+                }
+                ClientExtension::KeyShare { group, opaque } => {
+                    //info!("key_share ext");
+                    buf.with_u16_length(|buf| {
+                        // one key-share
+                        buf.push_u16(*group as u16)
+                            .map_err(|_| TlsError::EncodeError)?;
+
+                        buf.with_u16_length(|buf| buf.extend_from_slice(opaque.as_ref()))
+                            .map_err(|_| TlsError::EncodeError)
+                    })
+                }
+                ClientExtension::PreSharedKey {
+                    identities,
+                    hash_size,
+                } => {
+                    buf.with_u16_length(|buf| {
+                        for identity in identities {
+                            buf.with_u16_length(|buf| buf.extend_from_slice(identity))
+                                .map_err(|_| TlsError::EncodeError)?;
+
+                            // NOTE: No support for ticket age, set to 0 as recommended by RFC
+                            buf.push_u32(0).map_err(|_| TlsError::EncodeError)?;
+                        }
+                        Ok(())
+                    })
                     .map_err(|_| TlsError::EncodeError)?;
 
-                for &a in supported_signature_algorithms {
-                    buf.push_u16(a as u16).map_err(|_| TlsError::EncodeError)?;
-                }
-            }
-            ClientExtension::SignatureAlgorithmsCert {
-                supported_signature_algorithms,
-            } => {
-                //info!("supported sig algo cert ext");
-                buf.push_u16(supported_signature_algorithms.len() as u16 * 2)
-                    .map_err(|_| TlsError::EncodeError)?;
-
-                for &a in supported_signature_algorithms {
-                    buf.push_u16(a as u16).map_err(|_| TlsError::EncodeError)?;
-                }
-            }
-            ClientExtension::SupportedGroups { supported_groups } => {
-                //info!("supported groups ext");
-                buf.push_u16(supported_groups.len() as u16 * 2)
-                    .map_err(|_| TlsError::EncodeError)?;
-
-                for &g in supported_groups {
-                    buf.push_u16(g as u16).map_err(|_| TlsError::EncodeError)?;
-                }
-            }
-            ClientExtension::KeyShare { group, opaque } => {
-                //info!("key_share ext");
-                buf.push_u16(2 + 2 + opaque.len() as u16)
-                    .map_err(|_| TlsError::EncodeError)?;
-                // one key-share
-                buf.push_u16(*group as u16)
-                    .map_err(|_| TlsError::EncodeError)?;
-                buf.push_u16(opaque.len() as u16)
-                    .map_err(|_| TlsError::EncodeError)?;
-                buf.extend_from_slice(opaque.as_ref())
-                    .map_err(|_| TlsError::EncodeError)?;
-            }
-            ClientExtension::PreSharedKey {
-                identities,
-                hash_size,
-            } => {
-                // Each identity entry is of length identity.len() + u32 (for the ticket age)
-                let identities_len: usize = identities.iter().map(|i| i.len() + 2 + 4).sum();
-                buf.push_u16(identities_len as u16)
-                    .map_err(|_| TlsError::EncodeError)?;
-                for identity in identities {
-                    buf.push_u16(identity.len() as u16)
+                    // NOTE: We encode binders later after computing the transcript.
+                    let binders_len = (1 + hash_size) * identities.len();
+                    buf.push_u16(binders_len as u16)
                         .map_err(|_| TlsError::EncodeError)?;
 
-                    buf.extend_from_slice(identity)
-                        .map_err(|_| TlsError::EncodeError)?;
+                    for _ in 0..binders_len {
+                        buf.push(0).map_err(|_| TlsError::EncodeError)?;
+                    }
 
-                    // NOTE: No support for ticket age, set to 0 as recommended by RFC
-                    buf.push_u32(0).map_err(|_| TlsError::EncodeError)?;
+                    Ok(())
                 }
-
-                // NOTE: We encode binders later after computing the transcript.
-                let binders_len = (1 + hash_size) * identities.len();
-                buf.push_u16(binders_len as u16)
-                    .map_err(|_| TlsError::EncodeError)?;
-
-                for _ in 0..binders_len {
-                    buf.push(0).map_err(|_| TlsError::EncodeError)?;
+                ClientExtension::MaxFragmentLength(len) => {
+                    //info!("max fragment length");
+                    buf.push(*len as u8).map_err(|_| TlsError::EncodeError)
                 }
             }
-            ClientExtension::MaxFragmentLength(len) => {
-                //info!("max fragment length");
-                buf.push(*len as u8).map_err(|_| TlsError::EncodeError)?;
-            }
-        }
-
-        //info!("tail at {}", buf.len());
-        let extension_length = (buf.len() - extension_length_marker) as u16 - 2;
-        //info!("len: {}", extension_length);
-
-        buf.set_u16(extension_length_marker, extension_length)?;
-
-        Ok(())
+        })
     }
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -218,7 +218,7 @@ impl ClientExtension<'_> {
                         .map_err(|_| TlsError::EncodeError)?;
 
                     // NOTE: No support for ticket age, set to 0 as recommended by RFC
-                    buf.push_u32(0u32).map_err(|_| TlsError::EncodeError)?;
+                    buf.push_u32(0).map_err(|_| TlsError::EncodeError)?;
                 }
 
                 // NOTE: We encode binders later after computing the transcript.

--- a/src/handshake/client_hello.rs
+++ b/src/handshake/client_hello.rs
@@ -43,7 +43,7 @@ where
         let public_key = EncodedPoint::from(&self.secret.public_key());
         let public_key = public_key.as_ref();
 
-        buf.extend_from_slice(&LEGACY_VERSION.to_be_bytes())
+        buf.push_u16(LEGACY_VERSION)
             .map_err(|_| TlsError::EncodeError)?;
         buf.extend_from_slice(&self.random)
             .map_err(|_| TlsError::EncodeError)?;
@@ -56,9 +56,8 @@ where
         //for c in self.config.cipher_suites.iter() {
         //buf.extend_from_slice(&(*c as u16).to_be_bytes());
         //}
-        buf.extend_from_slice(&2u16.to_be_bytes())
-            .map_err(|_| TlsError::EncodeError)?;
-        buf.extend_from_slice(&CipherSuite::CODE_POINT.to_be_bytes())
+        buf.push_u16(2).map_err(|_| TlsError::EncodeError)?;
+        buf.push_u16(CipherSuite::CODE_POINT)
             .map_err(|_| TlsError::EncodeError)?;
 
         // compression methods, 1 byte of 0
@@ -120,13 +119,8 @@ where
 
         let extensions_length = (buf.len() - extension_length_marker - 2) as u16;
         //info!("extensions length: {:x?}", extensions_length.to_be_bytes());
-        buf.set(extension_length_marker, extensions_length.to_be_bytes()[0])
+        buf.set_u16(extension_length_marker, extensions_length)
             .map_err(|_| TlsError::EncodeError)?;
-        buf.set(
-            extension_length_marker + 1,
-            extensions_length.to_be_bytes()[1],
-        )
-        .map_err(|_| TlsError::EncodeError)?;
 
         Ok(())
     }

--- a/src/record.rs
+++ b/src/record.rs
@@ -90,8 +90,7 @@ where
             .map_err(|_| TlsError::EncodeError)?;
 
         let record_length_marker = buf.len();
-        buf.push(0).map_err(|_| TlsError::EncodeError)?;
-        buf.push(0).map_err(|_| TlsError::EncodeError)?;
+        buf.push_u16(0).map_err(|_| TlsError::EncodeError)?;
 
         let (range, mut buf) = match self {
             ClientRecord::Handshake(handshake, false) => {


### PR DESCRIPTION
u32::to_be_bytes returns an array where the 0th element is the most significant byte. When encoding a u24, this byte is 0, and we need to store bytes 1-3 instead of 0-2. This PR fixes this issue, and cleans up code by using less raw slice operations, and then some.

Commit c70f6b92aa391b5fa00b2bdb5557a0db794a20a0 is an experimental idea of which I'd like to hear your opinions. It abstracts the reserve-then-set-later pattern with a callback, so now we have a simple way to automate prepending length byte(s). There are more places it can be used if the idea gets a green light, otherwise it's easy enough to just drop the commit :)