### PR TITLE
Improve record encoding code

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -211,14 +211,11 @@ where
 
     /// Close a connection instance, returning the ownership of the config, random generator and the async I/O provider.
     async fn close_internal(&mut self) -> Result<(), TlsError> {
-        let record = ClientRecord::close_notify(self.opened);
-
         let (write_key_schedule, read_key_schedule) = self.key_schedule.as_split();
-        let len = encode_record(
+        let len = ClientRecord::close_notify(self.opened).encode(
             self.record_write_buf,
             read_key_schedule,
             write_key_schedule,
-            &record,
         )?;
 
         self.delegate

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -214,7 +214,7 @@ where
         let (write_key_schedule, read_key_schedule) = self.key_schedule.as_split();
         let len = ClientRecord::close_notify(self.opened).encode(
             self.record_write_buf,
-            read_key_schedule,
+            Some(read_key_schedule),
             write_key_schedule,
         )?;
 

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -214,7 +214,7 @@ where
         let record = ClientRecord::close_notify(self.opened);
 
         let (write_key_schedule, read_key_schedule) = self.key_schedule.as_split();
-        let (_, len) = encode_record(
+        let len = encode_record(
             self.record_write_buf,
             read_key_schedule,
             write_key_schedule,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -209,7 +209,7 @@ where
         let record = ClientRecord::close_notify(self.opened);
 
         let (write_key_schedule, read_key_schedule) = self.key_schedule.as_split();
-        let (_, len) = encode_record(
+        let len = encode_record(
             self.record_write_buf,
             read_key_schedule,
             write_key_schedule,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -206,14 +206,11 @@ where
     }
 
     fn close_internal(&mut self) -> Result<(), TlsError> {
-        let record = ClientRecord::close_notify(self.opened);
-
         let (write_key_schedule, read_key_schedule) = self.key_schedule.as_split();
-        let len = encode_record(
+        let len = ClientRecord::close_notify(self.opened).encode(
             self.record_write_buf,
             read_key_schedule,
             write_key_schedule,
-            &record,
         )?;
 
         self.delegate

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -209,7 +209,7 @@ where
         let (write_key_schedule, read_key_schedule) = self.key_schedule.as_split();
         let len = ClientRecord::close_notify(self.opened).encode(
             self.record_write_buf,
-            read_key_schedule,
+            Some(read_key_schedule),
             write_key_schedule,
         )?;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -380,7 +380,7 @@ where
     key_schedule.initialize_early_secret(config.psk.as_ref().map(|p| p.0))?;
     let (write_key_schedule, read_key_schedule) = key_schedule.as_split();
     let client_hello = ClientRecord::client_hello(config, rng);
-    let len = client_hello.encode(tx_buf, read_key_schedule, write_key_schedule)?;
+    let len = client_hello.encode(tx_buf, Some(read_key_schedule), write_key_schedule)?;
 
     if let ClientRecord::Handshake(ClientHandshake::ClientHello(client_hello), _) = client_hello {
         handshake.secret.replace(client_hello.secret);
@@ -505,7 +505,7 @@ where
     let (write_key_schedule, read_key_schedule) = key_schedule.as_split();
     let len = ClientRecord::Handshake(ClientHandshake::ClientCert(certificate), true).encode(
         tx_buf,
-        read_key_schedule,
+        Some(read_key_schedule),
         write_key_schedule,
     )?;
 
@@ -526,7 +526,7 @@ where
     let (write_key_schedule, read_key_schedule) = key_schedule.as_split();
     let len = ClientRecord::Handshake(ClientHandshake::Finished(client_finished), true).encode(
         tx_buf,
-        read_key_schedule,
+        Some(read_key_schedule),
         write_key_schedule,
     )?;
 


### PR DESCRIPTION
This PR is one step in the direction of a write buffer. The intention is to introduce a builder that can encode records in write memory, then encrypt them if necessary, in-place. This PR moves most of the record encoding and touch-up into a single place, not counting encrypted application data building. The PR also cleans up weird and unnecessary return values.