### PR TITLE
Introduce a write buffer and use it to encode records

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -124,7 +124,7 @@ where
                 self.record_write_buf.pos += buffered;
             }
 
-            if self.record_write_buf.pos == max_block_size {
+            if self.record_write_buf.is_full() {
                 self.flush().await?;
             }
 

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -129,7 +129,7 @@ where
 
     /// Force all previously written, buffered bytes to be encoded into a tls record and written to the connection.
     pub async fn flush(&mut self) -> Result<(), TlsError> {
-        if self.record_write_buf.pos > 0 {
+        if !self.record_write_buf.is_empty() {
             let len = encode_application_data_record_in_place(
                 self.record_write_buf.buffer,
                 self.record_write_buf.pos,

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -3,7 +3,7 @@ use crate::common::decrypted_read_handler::DecryptedReadHandler;
 use crate::connection::*;
 use crate::key_schedule::KeySchedule;
 use crate::read_buffer::ReadBuffer;
-use crate::record::ClientRecord;
+use crate::record::{encode_application_data_in_place, ClientRecord};
 use crate::record_reader::RecordReader;
 use crate::write_buffer::WriteBuffer;
 use crate::TlsError;
@@ -130,10 +130,12 @@ where
     /// Force all previously written, buffered bytes to be encoded into a tls record and written to the connection.
     pub async fn flush(&mut self) -> Result<(), TlsError> {
         if !self.record_write_buf.is_empty() {
-            let len = encode_application_data_record_in_place(
+            let key_schedule = self.key_schedule.write_state();
+
+            let len = encode_application_data_in_place(
                 self.record_write_buf.buffer,
                 self.record_write_buf.pos,
-                self.key_schedule.write_state(),
+                |buf| encrypt(key_schedule, buf),
             )?;
 
             self.delegate
@@ -141,7 +143,7 @@ where
                 .await
                 .map_err(|e| TlsError::Io(e.kind()))?;
 
-            self.key_schedule.write_state().increment_counter();
+            key_schedule.increment_counter();
             self.record_write_buf.pos = 0;
         }
 

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -132,11 +132,9 @@ where
         if !self.record_write_buf.is_empty() {
             let key_schedule = self.key_schedule.write_state();
 
-            let len = encode_application_data_in_place(
-                self.record_write_buf.buffer,
-                self.record_write_buf.pos,
-                |buf| encrypt(key_schedule, buf),
-            )?;
+            let len = encode_application_data_in_place(&mut self.record_write_buf, |buf| {
+                encrypt(key_schedule, buf)
+            })?;
 
             self.delegate
                 .write_all(&self.record_write_buf.buffer[..len])

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -132,9 +132,7 @@ where
         if !self.record_write_buf.is_empty() {
             let key_schedule = self.key_schedule.write_state();
 
-            let len = encode_application_data_in_place(&mut self.record_write_buf, |buf| {
-                encrypt(key_schedule, buf)
-            })?;
+            let len = encode_application_data_in_place(&mut self.record_write_buf, key_schedule)?;
 
             self.delegate
                 .write_all(&self.record_write_buf.buffer[..len])

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -127,7 +127,7 @@ where
 
     /// Force all previously written, buffered bytes to be encoded into a tls record and written to the connection.
     pub fn flush(&mut self) -> Result<(), TlsError> {
-        if self.record_write_buf.pos > 0 {
+        if !self.record_write_buf.is_empty() {
             let key_schedule = self.key_schedule.write_state();
             let len = encode_application_data_record_in_place(
                 self.record_write_buf.buffer,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -130,11 +130,9 @@ where
         if !self.record_write_buf.is_empty() {
             let key_schedule = self.key_schedule.write_state();
 
-            let len = encode_application_data_in_place(
-                self.record_write_buf.buffer,
-                self.record_write_buf.pos,
-                |buf| encrypt(key_schedule, buf),
-            )?;
+            let len = encode_application_data_in_place(&mut self.record_write_buf, |buf| {
+                encrypt(key_schedule, buf)
+            })?;
 
             self.delegate
                 .write_all(&self.record_write_buf.buffer[..len])

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -122,7 +122,7 @@ where
                 self.record_write_buf.pos += buffered;
             }
 
-            if self.record_write_buf.pos == max_block_size {
+            if self.record_write_buf.is_full() {
                 self.flush()?;
             }
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -5,7 +5,7 @@ use crate::key_schedule::KeySchedule;
 use crate::read_buffer::ReadBuffer;
 use crate::record::ClientRecord;
 use crate::record_reader::RecordReader;
-use crate::write_buffer::{WriteBuffer, TLS_RECORD_OVERHEAD};
+use crate::write_buffer::WriteBuffer;
 use embedded_io::blocking::BufRead;
 use embedded_io::Error as _;
 use embedded_io::{
@@ -113,14 +113,7 @@ where
     /// Returns the number of bytes buffered/written.
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, TlsError> {
         if self.opened {
-            let max_block_size = self.record_write_buf.buffer.len() - TLS_RECORD_OVERHEAD;
-            let buffered = usize::min(buf.len(), max_block_size - self.record_write_buf.pos);
-            if buffered > 0 {
-                self.record_write_buf.buffer
-                    [self.record_write_buf.pos..self.record_write_buf.pos + buffered]
-                    .copy_from_slice(&buf[..buffered]);
-                self.record_write_buf.pos += buffered;
-            }
+            let buffered = self.record_write_buf.append(buf);
 
             if self.record_write_buf.is_full() {
                 self.flush()?;

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -130,9 +130,7 @@ where
         if !self.record_write_buf.is_empty() {
             let key_schedule = self.key_schedule.write_state();
 
-            let len = encode_application_data_in_place(&mut self.record_write_buf, |buf| {
-                encrypt(key_schedule, buf)
-            })?;
+            let len = encode_application_data_in_place(&mut self.record_write_buf, key_schedule)?;
 
             self.delegate
                 .write_all(&self.record_write_buf.buffer[..len])

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -5,6 +5,7 @@ use crate::key_schedule::KeySchedule;
 use crate::read_buffer::ReadBuffer;
 use crate::record::ClientRecord;
 use crate::record_reader::RecordReader;
+use crate::write_buffer::{WriteBuffer, TLS_RECORD_OVERHEAD};
 use embedded_io::blocking::BufRead;
 use embedded_io::Error as _;
 use embedded_io::{
@@ -15,9 +16,6 @@ use rand_core::{CryptoRng, RngCore};
 
 pub use crate::config::*;
 pub use crate::TlsError;
-
-// Some space needed by TLS record
-const TLS_RECORD_OVERHEAD: usize = 128;
 
 /// Type representing an async TLS connection. An instance of this type can
 /// be used to establish a TLS connection, write and read encrypted data over this connection,
@@ -31,8 +29,7 @@ where
     opened: bool,
     key_schedule: KeySchedule<CipherSuite>,
     record_reader: RecordReader<'a, CipherSuite>,
-    record_write_buf: &'a mut [u8],
-    write_pos: usize,
+    record_write_buf: WriteBuffer<'a>,
     decrypted: DecryptedBufferInfo,
 }
 
@@ -57,17 +54,12 @@ where
         record_read_buf: &'a mut [u8],
         record_write_buf: &'a mut [u8],
     ) -> Self {
-        assert!(
-            record_write_buf.len() > TLS_RECORD_OVERHEAD,
-            "The write buffer must be sufficiently large to include the tls record overhead"
-        );
         Self {
             delegate,
             opened: false,
             key_schedule: KeySchedule::new(),
             record_reader: RecordReader::new(record_read_buf),
-            record_write_buf,
-            write_pos: 0,
+            record_write_buf: WriteBuffer::new(record_write_buf),
             decrypted: DecryptedBufferInfo::default(),
         }
     }
@@ -95,7 +87,7 @@ where
                 &mut self.delegate,
                 &mut handshake,
                 &mut self.record_reader,
-                self.record_write_buf,
+                &mut self.record_write_buf,
                 &mut self.key_schedule,
                 context.config,
                 context.rng,
@@ -121,15 +113,16 @@ where
     /// Returns the number of bytes buffered/written.
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, TlsError> {
         if self.opened {
-            let max_block_size = self.record_write_buf.len() - TLS_RECORD_OVERHEAD;
-            let buffered = usize::min(buf.len(), max_block_size - self.write_pos);
+            let max_block_size = self.record_write_buf.buffer.len() - TLS_RECORD_OVERHEAD;
+            let buffered = usize::min(buf.len(), max_block_size - self.record_write_buf.pos);
             if buffered > 0 {
-                self.record_write_buf[self.write_pos..self.write_pos + buffered]
+                self.record_write_buf.buffer
+                    [self.record_write_buf.pos..self.record_write_buf.pos + buffered]
                     .copy_from_slice(&buf[..buffered]);
-                self.write_pos += buffered;
+                self.record_write_buf.pos += buffered;
             }
 
-            if self.write_pos == max_block_size {
+            if self.record_write_buf.pos == max_block_size {
                 self.flush()?;
             }
 
@@ -141,20 +134,20 @@ where
 
     /// Force all previously written, buffered bytes to be encoded into a tls record and written to the connection.
     pub fn flush(&mut self) -> Result<(), TlsError> {
-        if self.write_pos > 0 {
+        if self.record_write_buf.pos > 0 {
             let key_schedule = self.key_schedule.write_state();
             let len = encode_application_data_record_in_place(
-                self.record_write_buf,
-                self.write_pos,
+                self.record_write_buf.buffer,
+                self.record_write_buf.pos,
                 key_schedule,
             )?;
 
             self.delegate
-                .write_all(&self.record_write_buf[..len])
+                .write_all(&self.record_write_buf.buffer[..len])
                 .map_err(|e| TlsError::Io(e.kind()))?;
 
             key_schedule.increment_counter();
-            self.write_pos = 0;
+            self.record_write_buf.pos = 0;
         }
 
         Ok(())
@@ -209,13 +202,13 @@ where
     fn close_internal(&mut self) -> Result<(), TlsError> {
         let (write_key_schedule, read_key_schedule) = self.key_schedule.as_split();
         let len = ClientRecord::close_notify(self.opened).encode(
-            self.record_write_buf,
+            self.record_write_buf.buffer,
             Some(read_key_schedule),
             write_key_schedule,
         )?;
 
         self.delegate
-            .write_all(&self.record_write_buf[..len])
+            .write_all(&self.record_write_buf.buffer[..len])
             .map_err(|e| TlsError::Io(e.kind()))?;
 
         self.key_schedule.write_state().increment_counter();

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -3,7 +3,7 @@ use crate::common::decrypted_read_handler::DecryptedReadHandler;
 use crate::connection::*;
 use crate::key_schedule::KeySchedule;
 use crate::read_buffer::ReadBuffer;
-use crate::record::ClientRecord;
+use crate::record::{encode_application_data_in_place, ClientRecord};
 use crate::record_reader::RecordReader;
 use crate::write_buffer::WriteBuffer;
 use embedded_io::blocking::BufRead;
@@ -129,10 +129,11 @@ where
     pub fn flush(&mut self) -> Result<(), TlsError> {
         if !self.record_write_buf.is_empty() {
             let key_schedule = self.key_schedule.write_state();
-            let len = encode_application_data_record_in_place(
+
+            let len = encode_application_data_in_place(
                 self.record_write_buf.buffer,
                 self.record_write_buf.pos,
-                key_schedule,
+                |buf| encrypt(key_schedule, buf),
             )?;
 
             self.delegate

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -132,7 +132,7 @@ where
     CipherSuite: TlsCipherSuite,
 {
     let client_key = key_schedule.get_key()?;
-    let nonce = &key_schedule.get_nonce()?;
+    let nonce = key_schedule.get_nonce()?;
     // trace!("encrypt key {:02x?}", client_key);
     // trace!("encrypt nonce {:02x?}", nonce);
     // trace!("plaintext {} {:02x?}", buf.len(), buf.as_slice(),);
@@ -158,7 +158,7 @@ where
     ];
 
     crypto
-        .encrypt_in_place(nonce, &additional_data, buf)
+        .encrypt_in_place(&nonce, &additional_data, buf)
         .map_err(|_| TlsError::InvalidApplicationData)?;
     Ok(buf.len())
 }
@@ -292,7 +292,8 @@ impl<'a> State {
     {
         match self {
             State::ClientHello => {
-                let (state, tx) = client_hello(key_schedule, config, rng, tx_buf.buffer, handshake)?;
+                let (state, tx) =
+                    client_hello(key_schedule, config, rng, tx_buf.buffer, handshake)?;
 
                 respond_blocking(tx, transport, key_schedule)?;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,7 @@
 use crate::config::{TlsCipherSuite, TlsConfig, TlsVerifier};
 use crate::handshake::{ClientHandshake, ServerHandshake};
 use crate::key_schedule::{HashOutputSize, KeySchedule, ReadKeySchedule, WriteKeySchedule};
-use crate::record::{encode_application_data_in_place, ClientRecord, ServerRecord};
+use crate::record::{ClientRecord, ServerRecord};
 use crate::record_reader::RecordReader;
 use crate::write_buffer::WriteBuffer;
 use crate::TlsError;
@@ -161,17 +161,6 @@ where
         .encrypt_in_place(&nonce, &additional_data, buf)
         .map_err(|_| TlsError::InvalidApplicationData)?;
     Ok(buf.len())
-}
-
-pub fn encode_application_data_record_in_place<CipherSuite>(
-    tx_buf: &mut [u8],
-    data_len: usize,
-    key_schedule: &mut WriteKeySchedule<CipherSuite>,
-) -> Result<usize, TlsError>
-where
-    CipherSuite: TlsCipherSuite + 'static,
-{
-    encode_application_data_in_place(tx_buf, data_len, |buf| encrypt(key_schedule, buf))
 }
 
 pub struct Handshake<CipherSuite, Verifier>

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -422,6 +422,7 @@ where
 {
     let mut state = State::ServerVerify;
     decrypt_record(key_schedule.read_state(), record, |key_schedule, record| {
+        debug!("record = {:?}", record.content_type());
         match record {
             ServerRecord::Handshake(server_handshake) => match server_handshake {
                 ServerHandshake::EncryptedExtensions(_) => {}

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -11,11 +11,11 @@ use crate::handshake::encrypted_extensions::EncryptedExtensions;
 use crate::handshake::finished::Finished;
 use crate::handshake::new_session_ticket::NewSessionTicket;
 use crate::handshake::server_hello::ServerHello;
+use crate::key_schedule::HashOutputSize;
 use crate::parse_buffer::ParseBuffer;
 use crate::TlsError;
 use core::fmt::{Debug, Formatter};
 use core::ops::Range;
-use digest::OutputSizeUser;
 use sha2::Digest;
 
 pub mod binder;
@@ -79,7 +79,7 @@ where
 {
     ClientCert(CertificateRef<'a>),
     ClientHello(ClientHello<'config, CipherSuite>),
-    Finished(Finished<<CipherSuite::Hash as OutputSizeUser>::OutputSize>),
+    Finished(Finished<HashOutputSize<CipherSuite>>),
 }
 
 impl<'config, 'a, CipherSuite> ClientHandshake<'config, 'a, CipherSuite>

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -159,10 +159,8 @@ where
     }
 
     pub fn get_nonce(&self) -> Result<IvArray<CipherSuite>, TlsError> {
-        Ok(KeySchedule::<CipherSuite>::get_nonce(
-            self.counter,
-            &self.get_iv()?,
-        ))
+        let iv = self.get_iv()?;
+        Ok(KeySchedule::<CipherSuite>::get_nonce(self.counter, &iv))
     }
 
     fn calculate_traffic_secret(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ mod record;
 mod record_reader;
 mod signature_schemes;
 mod supported_versions;
+mod write_buffer;
 
 #[cfg(feature = "webpki")]
 pub mod webpki;

--- a/src/record.rs
+++ b/src/record.rs
@@ -215,13 +215,11 @@ where
         };
         let mut buf = wrapped.rewind();
 
-        let record_length = (buf.len() as u16 - record_length_marker as u16) - 2;
+        let record_length = (buf.len() - record_length_marker) as u16 - 2;
 
         // trace!("record len {}", record_length);
 
-        buf.set(record_length_marker, record_length.to_be_bytes()[0])
-            .map_err(|_| TlsError::EncodeError)?;
-        buf.set(record_length_marker + 1, record_length.to_be_bytes()[1])
+        buf.set_u16(record_length_marker, record_length)
             .map_err(|_| TlsError::EncodeError)?;
 
         Ok(buf.len())
@@ -251,8 +249,7 @@ where
     header.encode(&mut buf)?;
 
     let record_length_marker = buf.len();
-    buf.push(0).map_err(|_| TlsError::EncodeError)?;
-    buf.push(0).map_err(|_| TlsError::EncodeError)?;
+    buf.push_u16(0).map_err(|_| TlsError::EncodeError)?;
 
     assert_eq!(5, buf.len());
 
@@ -264,11 +261,9 @@ where
     let _ = encrypt(key_schedule, &mut wrapped)?;
 
     let mut buf = wrapped.rewind();
-    let record_length = (buf.len() as u16 - record_length_marker as u16) - 2;
+    let record_length = (buf.len() - record_length_marker) as u16 - 2;
 
-    buf.set(record_length_marker, record_length.to_be_bytes()[0])
-        .map_err(|_| TlsError::EncodeError)?;
-    buf.set(record_length_marker + 1, record_length.to_be_bytes()[1])
+    buf.set_u16(record_length_marker, record_length)
         .map_err(|_| TlsError::EncodeError)?;
 
     Ok(buf.len())

--- a/src/record.rs
+++ b/src/record.rs
@@ -124,9 +124,11 @@ where
         let mut wrapped = buf.forward();
         match self {
             ClientRecord::Handshake(handshake, false) => {
-                let range = handshake.encode(&mut wrapped)?;
+                let start = wrapped.len();
+                handshake.encode(&mut wrapped)?;
+                let end = wrapped.len();
 
-                let enc_buf = &mut wrapped.as_mut_slice()[range];
+                let enc_buf = &mut wrapped.as_mut_slice()[start..end];
                 let transcript = read_key_schedule
                     .ok_or(TlsError::InternalError)?
                     .transcript_hash();
@@ -169,8 +171,11 @@ where
                 let transcript = read_key_schedule
                     .ok_or(TlsError::InternalError)?
                     .transcript_hash();
-                let range = handshake.encode(&mut wrapped)?;
-                transcript.update(&wrapped.as_slice()[range]);
+
+                let start = wrapped.len();
+                handshake.encode(&mut wrapped)?;
+                let end = wrapped.len();
+                transcript.update(&wrapped.as_slice()[start..end]);
                 wrapped
                     .push(ContentType::Handshake as u8)
                     .map_err(|_| TlsError::EncodeError)?;

--- a/src/record.rs
+++ b/src/record.rs
@@ -312,6 +312,15 @@ impl RecordHeader {
 }
 
 impl<'a, N: ArrayLength<u8>> ServerRecord<'a, N> {
+    pub fn content_type(&self) -> ContentType {
+        match self {
+            ServerRecord::Handshake(_) => ContentType::Handshake,
+            ServerRecord::ChangeCipherSpec(_) => ContentType::ChangeCipherSpec,
+            ServerRecord::Alert(_) => ContentType::Alert,
+            ServerRecord::ApplicationData(_) => ContentType::ApplicationData,
+        }
+    }
+
     pub fn decode<D>(
         header: RecordHeader,
         data: &'a mut [u8],

--- a/src/write_buffer.rs
+++ b/src/write_buffer.rs
@@ -38,7 +38,7 @@ impl<'a> WriteBuffer<'a> {
     }
 
     pub fn append(&mut self, buf: &[u8]) -> usize {
-        let buffered = usize::min(buf.len(), self.max_block_size() - self.pos);
+        let buffered = usize::min(buf.len(), self.space());
         if buffered > 0 {
             self.buffer[self.pos..self.pos + buffered].copy_from_slice(&buf[..buffered]);
             self.pos += buffered;

--- a/src/write_buffer.rs
+++ b/src/write_buffer.rs
@@ -31,4 +31,12 @@ impl<'a> WriteBuffer<'a> {
         }
         buffered
     }
+
+    pub fn len(&self) -> usize {
+        self.pos
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }

--- a/src/write_buffer.rs
+++ b/src/write_buffer.rs
@@ -1,9 +1,19 @@
+use crate::{
+    buffer::CryptoBuffer,
+    connection::encrypt,
+    content_types::ContentType,
+    key_schedule::{ReadKeySchedule, WriteKeySchedule},
+    record::{ClientRecord, ClientRecordHeader},
+    TlsCipherSuite, TlsError,
+};
+
 // Some space needed by TLS record
 pub const TLS_RECORD_OVERHEAD: usize = 128;
 
 pub struct WriteBuffer<'a> {
-    pub buffer: &'a mut [u8],
-    pub pos: usize,
+    buffer: &'a mut [u8],
+    pos: usize,
+    current_header: Option<ClientRecordHeader>,
 }
 
 impl<'a> WriteBuffer<'a> {
@@ -12,7 +22,11 @@ impl<'a> WriteBuffer<'a> {
             buffer.len() > TLS_RECORD_OVERHEAD,
             "The write buffer must be sufficiently large to include the tls record overhead"
         );
-        Self { buffer, pos: 0 }
+        Self {
+            buffer,
+            pos: 0,
+            current_header: None,
+        }
     }
 
     fn max_block_size(&self) -> usize {
@@ -42,5 +56,95 @@ impl<'a> WriteBuffer<'a> {
 
     pub fn space(&self) -> usize {
         self.max_block_size() - self.pos
+    }
+
+    pub fn contains(&self, header: ClientRecordHeader) -> bool {
+        self.current_header == Some(header)
+    }
+
+    fn with_buffer(
+        &mut self,
+        op: impl FnOnce(CryptoBuffer) -> Result<CryptoBuffer, TlsError>,
+    ) -> Result<(), TlsError> {
+        let buf = CryptoBuffer::wrap_with_pos(self.buffer, self.pos);
+
+        match op(buf) {
+            Ok(buf) => {
+                self.pos = buf.len();
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    pub(crate) fn start_record(&mut self, header: ClientRecordHeader) -> Result<(), TlsError> {
+        debug_assert!(self.current_header.is_none());
+
+        debug!("start_record({:?})", header);
+        self.current_header = Some(header);
+
+        self.with_buffer(|mut buf| {
+            header.encode(&mut buf)?;
+            buf.push_u16(0)?;
+            Ok(buf.rewind())
+        })
+    }
+
+    pub(crate) fn close_record<CipherSuite>(
+        &mut self,
+        write_key_schedule: &mut WriteKeySchedule<CipherSuite>,
+    ) -> Result<&[u8], TlsError>
+    where
+        CipherSuite: TlsCipherSuite,
+    {
+        let header = self.current_header.take().unwrap();
+        self.with_buffer(|mut buf| {
+            if header == ClientRecordHeader::ApplicationData {
+                buf.push(ContentType::ApplicationData as u8)
+                    .map_err(|_| TlsError::EncodeError)?;
+            }
+
+            if header.is_encrypted() {
+                let mut buf = buf.offset(5);
+                encrypt(write_key_schedule, &mut buf)?;
+                return Ok(buf.rewind());
+            }
+            Ok(buf)
+        })?;
+        const HEADER_SIZE: u16 = 5;
+        let [upper, lower] = (self.pos as u16 - HEADER_SIZE).to_be_bytes();
+
+        self.buffer[3] = upper;
+        self.buffer[4] = lower;
+
+        let slice = &self.buffer[..self.pos];
+
+        self.pos = 0;
+        self.current_header = None;
+
+        Ok(slice)
+    }
+
+    pub fn write_record<CipherSuite>(
+        &mut self,
+        record: &ClientRecord<CipherSuite>,
+        write_key_schedule: &mut WriteKeySchedule<CipherSuite>,
+        read_key_schedule: Option<&mut ReadKeySchedule<CipherSuite>>,
+    ) -> Result<&[u8], TlsError>
+    where
+        CipherSuite: TlsCipherSuite,
+    {
+        if self.current_header.is_some() {
+            return Err(TlsError::InternalError);
+        }
+
+        self.start_record(record.header())?;
+        self.with_buffer(|buf| {
+            let mut buf = buf.forward();
+            record.encode_payload(&mut buf)?;
+            record.finish_record(&mut buf, read_key_schedule, write_key_schedule)?;
+            Ok(buf.rewind())
+        })?;
+        self.close_record(write_key_schedule)
     }
 }

--- a/src/write_buffer.rs
+++ b/src/write_buffer.rs
@@ -1,10 +1,11 @@
 use crate::{
     buffer::CryptoBuffer,
+    config::TlsCipherSuite,
     connection::encrypt,
     content_types::ContentType,
     key_schedule::{ReadKeySchedule, WriteKeySchedule},
     record::{ClientRecord, ClientRecordHeader},
-    TlsCipherSuite, TlsError,
+    TlsError,
 };
 
 // Some space needed by TLS record

--- a/src/write_buffer.rs
+++ b/src/write_buffer.rs
@@ -14,4 +14,9 @@ impl<'a> WriteBuffer<'a> {
         );
         Self { buffer, pos: 0 }
     }
+
+    pub fn is_full(&self) -> bool {
+        let max_block_size = self.buffer.len() - TLS_RECORD_OVERHEAD;
+        self.pos == max_block_size
+    }
 }

--- a/src/write_buffer.rs
+++ b/src/write_buffer.rs
@@ -39,4 +39,8 @@ impl<'a> WriteBuffer<'a> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    pub fn space(&self) -> usize {
+        self.max_block_size() - self.pos
+    }
 }

--- a/src/write_buffer.rs
+++ b/src/write_buffer.rs
@@ -1,0 +1,17 @@
+// Some space needed by TLS record
+pub const TLS_RECORD_OVERHEAD: usize = 128;
+
+pub struct WriteBuffer<'a> {
+    pub buffer: &'a mut [u8],
+    pub pos: usize,
+}
+
+impl<'a> WriteBuffer<'a> {
+    pub fn new(buffer: &'a mut [u8]) -> Self {
+        debug_assert!(
+            buffer.len() > TLS_RECORD_OVERHEAD,
+            "The write buffer must be sufficiently large to include the tls record overhead"
+        );
+        Self { buffer, pos: 0 }
+    }
+}

--- a/src/write_buffer.rs
+++ b/src/write_buffer.rs
@@ -15,8 +15,20 @@ impl<'a> WriteBuffer<'a> {
         Self { buffer, pos: 0 }
     }
 
+    fn max_block_size(&self) -> usize {
+        self.buffer.len() - TLS_RECORD_OVERHEAD
+    }
+
     pub fn is_full(&self) -> bool {
-        let max_block_size = self.buffer.len() - TLS_RECORD_OVERHEAD;
-        self.pos == max_block_size
+        self.pos == self.max_block_size()
+    }
+
+    pub fn append(&mut self, buf: &[u8]) -> usize {
+        let buffered = usize::min(buf.len(), self.max_block_size() - self.pos);
+        if buffered > 0 {
+            self.buffer[self.pos..self.pos + buffered].copy_from_slice(&buf[..buffered]);
+            self.pos += buffered;
+        }
+        buffered
     }
 }


### PR DESCRIPTION
Closes #91 
Closes #92

In theory, we could encode multiple records in the same buffer without flushing but flushing means we don't have to deal with the insufficient buffer case where we would need to flush anyway.

The PR avoids copy-shifting every ApplicationData by 5 bytes, and wraps a bunch of raw slice operations. It also flushed before sending the close alert so all writes are flushed from now on.