### PR TITLE
Validate extensions and abort on error

### DIFF
--- a/src/common/decrypted_read_handler.rs
+++ b/src/common/decrypted_read_handler.rs
@@ -53,7 +53,9 @@ impl DecryptedReadHandler<'_> {
             }
             ServerRecord::ChangeCipherSpec(_) => Err(TlsError::InternalError),
             ServerRecord::Handshake(ServerHandshake::NewSessionTicket(_)) => {
-                // Ignore
+                // TODO: we should validate extensions and abort. We can do this automatically
+                // as long as the connection is unsplit, however, split connections must be aborted
+                // by the user.
                 Ok(())
             }
             _ => {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -10,7 +10,7 @@ use crate::supported_versions::ProtocolVersions;
 use crate::TlsError;
 use heapless::Vec;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ExtensionType {
     ServerName = 0,
@@ -19,7 +19,7 @@ pub enum ExtensionType {
     SupportedGroups = 10,
     SignatureAlgorithms = 13,
     UseSrtp = 14,
-    Heatbeat = 15,
+    Heartbeat = 15,
     ApplicationLayerProtocolNegotiation = 16,
     SignedCertificateTimestamp = 18,
     ClientCertificateType = 19,
@@ -47,7 +47,7 @@ impl ExtensionType {
             10 => Some(Self::SupportedGroups),
             13 => Some(Self::SignatureAlgorithms),
             14 => Some(Self::UseSrtp),
-            15 => Some(Self::Heatbeat),
+            15 => Some(Self::Heartbeat),
             16 => Some(Self::ApplicationLayerProtocolNegotiation),
             18 => Some(Self::SignedCertificateTimestamp),
             19 => Some(Self::ClientCertificateType),

--- a/src/extensions/server.rs
+++ b/src/extensions/server.rs
@@ -1,3 +1,4 @@
+use crate::alert::{AlertDescription, AlertLevel};
 use crate::extensions::common::KeyShareEntry;
 use crate::extensions::ExtensionType;
 use crate::parse_buffer::{ParseBuffer, ParseError};
@@ -78,16 +79,16 @@ impl<'a> ServerExtension<'a> {
                 "{:?} extension is not allowed in this context",
                 extension_type
             );
+
             // Section 4.2.  Extensions
             // If an implementation receives an extension
             // which it recognizes and which is not specified for the message in
             // which it appears, it MUST abort the handshake with an
             // "illegal_parameter" alert.
-
-            // TODO: indicate to caller that we have to abort
-            // return Err(TlsError::AbortHandshake(AlertDescription::IllegalParameter))
-
-            return Err(TlsError::InvalidHandshake);
+            return Err(TlsError::AbortHandshake(
+                AlertLevel::Fatal,
+                AlertDescription::IllegalParameter,
+            ));
         }
 
         let extension_length = buf

--- a/src/handshake/client_hello.rs
+++ b/src/handshake/client_hello.rs
@@ -66,6 +66,10 @@ where
 
         // extensions (1+)
         buf.with_u16_length(|buf| {
+            // Section 4.2.1.  Supported Versions
+            // Implementations of this specification MUST send this extension in the
+            // ClientHello containing all versions of TLS which they are prepared to
+            // negotiate
             ClientExtension::SupportedVersions {
                 versions: Vec::from_slice(&[TLS13]).unwrap(),
             }
@@ -92,13 +96,16 @@ where
             }
             .encode(buf)?;
 
-            if let Some(server_name) = self.config.server_name.as_ref() {
+            if let Some(server_name) = self.config.server_name {
                 // TODO Add SNI extension
                 ClientExtension::ServerName { server_name }.encode(buf)?;
             }
 
-            // IMPORTANT: The pre shared keys must be encoded last, since we encode the binders
-            // at a later stage
+            // Section 4.2
+            // When multiple extensions of different types are present, the
+            // extensions MAY appear in any order, with the exception of
+            // "pre_shared_key" which MUST be the last extension in
+            // the ClientHello.
             if let Some((_, identities)) = &self.config.psk {
                 ClientExtension::PreSharedKey {
                     identities: identities.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub enum TlsError {
     Unimplemented,
     MissingHandshake,
     HandshakeAborted(alert::AlertLevel, alert::AlertDescription),
+    AbortHandshake(alert::AlertLevel, alert::AlertDescription),
     IoError,
     InternalError,
     InvalidRecord,

--- a/tests/early_data_test.rs
+++ b/tests/early_data_test.rs
@@ -1,0 +1,92 @@
+#![macro_use]
+#![allow(incomplete_features)]
+#![feature(async_fn_in_trait)]
+#![feature(impl_trait_projections)]
+use embedded_io::adapters::FromStd;
+use embedded_io::blocking::{Read, Write};
+use rand_core::OsRng;
+use std::net::SocketAddr;
+use std::sync::Once;
+
+mod tlsserver;
+
+static INIT: Once = Once::new();
+static mut ADDR: Option<SocketAddr> = None;
+
+fn setup() -> SocketAddr {
+    use mio::net::TcpListener;
+    INIT.call_once(|| {
+        env_logger::init();
+
+        let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+
+        let listener = TcpListener::bind(addr).expect("cannot listen on port");
+        let addr = listener
+            .local_addr()
+            .expect("error retrieving socket address");
+
+        std::thread::spawn(move || {
+            use tlsserver::*;
+
+            let versions = &[&rustls::version::TLS13];
+
+            let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+
+            let certs = load_certs(&test_dir.join("data").join("server-cert.pem"));
+            let privkey = load_private_key(&test_dir.join("data").join("server-key.pem"));
+
+            let mut config = rustls::ServerConfig::builder()
+                .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
+                .with_kx_groups(&rustls::ALL_KX_GROUPS)
+                .with_protocol_versions(versions)
+                .unwrap()
+                .with_no_client_auth()
+                .with_single_cert(certs, privkey)
+                .unwrap();
+
+            config.max_early_data_size = 512;
+
+            run_with_config(listener, config);
+        });
+        unsafe { ADDR.replace(addr) };
+    });
+    unsafe { ADDR.unwrap() }
+}
+
+#[test]
+fn early_data_ignored() {
+    use embedded_tls::blocking::*;
+    use std::net::TcpStream;
+
+    let addr = setup();
+    let pem = include_str!("data/ca-cert.pem");
+    let der = pem_parser::pem_to_der(pem);
+
+    let stream = TcpStream::connect(addr).expect("error connecting to server");
+
+    log::info!("Connected");
+    let mut read_record_buffer = [0; 16384];
+    let mut write_record_buffer = [0; 16384];
+    let config = TlsConfig::new()
+        .with_ca(Certificate::X509(&der[..]))
+        .with_server_name("localhost");
+
+    let mut tls: TlsConnection<FromStd<TcpStream>, Aes128GcmSha256> = TlsConnection::new(
+        FromStd::new(stream),
+        &mut read_record_buffer,
+        &mut write_record_buffer,
+    );
+
+    tls.open::<OsRng, NoVerify>(TlsContext::new(&config, &mut OsRng))
+        .expect("error establishing TLS connection");
+
+    tls.write_all(b"ping").expect("Failed to write data");
+    tls.flush().expect("Failed to flush");
+
+    let mut buffer = [0; 4];
+    tls.read_exact(&mut buffer).expect("Failed to read data");
+
+    tls.close()
+        .map_err(|(_, e)| e)
+        .expect("error closing session");
+}


### PR DESCRIPTION
We'll still need to abort when reading forbidden extensions, but at least we don't trip over unimplemented optional ones.

cc #75 #11