### PR TITLE
Make max fragment length optional and send in client hello

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -86,7 +86,7 @@ where
             Handshake::new(Verifier::new(context.config.server_name));
         let mut state = State::ClientHello;
 
-        loop {
+        while state != State::ApplicationData {
             let next_state = state
                 .process(
                     &mut self.delegate,
@@ -100,11 +100,8 @@ where
                 .await?;
             trace!("State {:?} -> {:?}", state, next_state);
             state = next_state;
-            if let State::ApplicationData = state {
-                self.opened = true;
-                break;
-            }
         }
+        self.opened = true;
 
         Ok(())
     }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -86,7 +86,7 @@ where
             Handshake::new(Verifier::new(context.config.server_name));
         let mut state = State::ClientHello;
 
-        loop {
+        while state != State::ApplicationData {
             let next_state = state.process_blocking(
                 &mut self.delegate,
                 &mut handshake,
@@ -98,11 +98,8 @@ where
             )?;
             trace!("State {:?} -> {:?}", state, next_state);
             state = next_state;
-            if let State::ApplicationData = state {
-                self.opened = true;
-                break;
-            }
         }
+        self.opened = true;
 
         Ok(())
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -196,7 +196,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum State {
     ClientHello,

--- a/src/handshake/client_hello.rs
+++ b/src/handshake/client_hello.rs
@@ -80,6 +80,10 @@ where
             }
             .encode(buf)?;
 
+            if let Some(max_fragment_length) = self.config.max_fragment_length {
+                ClientExtension::MaxFragmentLength(max_fragment_length).encode(buf)?;
+            }
+
             ClientExtension::SupportedGroups {
                 supported_groups: self.config.named_groups.clone(),
             }

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -200,7 +200,7 @@ impl<'a, N: ArrayLength<u8>> ServerHandshake<'a, N> {
             HandshakeType::of(buf.read_u8().map_err(|_| TlsError::InvalidHandshake)?)
                 .ok_or(TlsError::InvalidHandshake)?;
 
-        // info!("Handshake type {:?}", handshake_type);
+        trace!("handshake = {:?}", handshake_type);
 
         let content_len = buf.read_u24().map_err(|_| TlsError::InvalidHandshake)?;
 

--- a/src/max_fragment_length.rs
+++ b/src/max_fragment_length.rs
@@ -1,8 +1,13 @@
+/// Maximum plaintext fragment length
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MaxFragmentLength {
+    /// 512 bytes
     Bits9 = 1,
+    /// 1024 bytes
     Bits10 = 2,
+    /// 2048 bytes
     Bits11 = 3,
+    /// 4096 bytes
     Bits12 = 4,
 }


### PR DESCRIPTION
One needs to be careful with this as servers may end up sending fragmented records (cc #110), but this setting can place a guarantee on the upper bounds of the size of the read/write buffer. One caveat is that the plaintext fragment length =/= record length so the buffers actually need some overhead.

Includes some minor improvements extracted from #109