### PR TITLE
Deduplicate and refactor some parsing related code

### DIFF
--- a/src/cipher_suites.rs
+++ b/src/cipher_suites.rs
@@ -1,3 +1,5 @@
+use crate::parse_buffer::{ParseBuffer, ParseError};
+
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CipherSuite {
@@ -10,15 +12,15 @@ pub enum CipherSuite {
 }
 
 impl CipherSuite {
-    pub fn of(num: u16) -> Option<Self> {
-        match num {
-            0x1301 => Some(Self::TlsAes128GcmSha256),
-            0x1302 => Some(Self::TlsAes256GcmSha384),
-            0x1303 => Some(Self::TlsChacha20Poly1305Sha256),
-            0x1304 => Some(Self::TlsAes128CcmSha256),
-            0x1305 => Some(Self::TlsAes128Ccm8Sha256),
-            0x00A8 => Some(Self::TlsPskAes128GcmSha256),
-            _ => None,
+    pub fn parse(buf: &mut ParseBuffer) -> Result<Self, ParseError> {
+        match buf.read_u16()? {
+            v if v == Self::TlsAes128GcmSha256 as u16 => Ok(Self::TlsAes128GcmSha256),
+            v if v == Self::TlsAes256GcmSha384 as u16 => Ok(Self::TlsAes256GcmSha384),
+            v if v == Self::TlsChacha20Poly1305Sha256 as u16 => Ok(Self::TlsChacha20Poly1305Sha256),
+            v if v == Self::TlsAes128CcmSha256 as u16 => Ok(Self::TlsAes128CcmSha256),
+            v if v == Self::TlsAes128Ccm8Sha256 as u16 => Ok(Self::TlsAes128Ccm8Sha256),
+            v if v == Self::TlsPskAes128GcmSha256 as u16 => Ok(Self::TlsPskAes128GcmSha256),
+            _ => Err(ParseError::InvalidData),
         }
     }
 }

--- a/src/common/decrypted_read_handler.rs
+++ b/src/common/decrypted_read_handler.rs
@@ -1,10 +1,8 @@
 use core::ops::Range;
 
-use generic_array::ArrayLength;
-
 use crate::{
     alert::AlertDescription, common::decrypted_buffer_info::DecryptedBufferInfo,
-    handshake::ServerHandshake, record::ServerRecord, TlsError,
+    handshake::ServerHandshake, record::ServerRecord, config::TlsCipherSuite, TlsError,
 };
 
 pub struct DecryptedReadHandler<'a> {
@@ -14,9 +12,9 @@ pub struct DecryptedReadHandler<'a> {
 }
 
 impl DecryptedReadHandler<'_> {
-    pub fn handle<N: ArrayLength<u8>>(
+    pub fn handle<CipherSuite: TlsCipherSuite>(
         &mut self,
-        record: ServerRecord<'_, N>,
+        record: ServerRecord<'_, CipherSuite>,
     ) -> Result<(), TlsError> {
         match record {
             ServerRecord::ApplicationData(data) => {

--- a/src/extensions/extension_data/key_share.rs
+++ b/src/extensions/extension_data/key_share.rs
@@ -108,27 +108,27 @@ mod tests {
     fn test_parse_empty() {
         setup();
         let buffer = [
-            0x00, 0x017, // Secp256r1
+            0x00, 0x17, // Secp256r1
             0x00, 0x00, // key_exchange length = 0 bytes
         ];
         let result = KeyShareEntry::parse(&mut ParseBuffer::new(&buffer)).unwrap();
 
         assert_eq!(NamedGroup::Secp256r1, result.group);
-        assert_eq!(0, result.opaque.as_ref().len());
+        assert_eq!(0, result.opaque.len());
     }
 
     #[test]
     fn test_parse() {
         setup();
         let buffer = [
-            0x00, 0x017, // Secp256r1
+            0x00, 0x17, // Secp256r1
             0x00, 0x02, // key_exchange length = 2 bytes
             0xAA, 0xBB,
         ];
         let result = KeyShareEntry::parse(&mut ParseBuffer::new(&buffer)).unwrap();
 
         assert_eq!(NamedGroup::Secp256r1, result.group);
-        assert_eq!(2, result.opaque.as_ref().len());
+        assert_eq!(2, result.opaque.len());
         assert_eq!([0xAA, 0xBB], result.opaque);
     }
 }

--- a/src/extensions/extension_data/max_fragment_length.rs
+++ b/src/extensions/extension_data/max_fragment_length.rs
@@ -26,9 +26,7 @@ pub enum MaxFragmentLength {
 
 impl MaxFragmentLength {
     pub fn parse(buf: &mut ParseBuffer) -> Result<Self, ParseError> {
-        let byte = buf.read_u8()?;
-
-        match byte {
+        match buf.read_u8()? {
             1 => Ok(Self::Bits9),
             2 => Ok(Self::Bits10),
             3 => Ok(Self::Bits11),

--- a/src/handshake/server_hello.rs
+++ b/src/handshake/server_hello.rs
@@ -9,7 +9,6 @@ use crate::parse_buffer::ParseBuffer;
 use crate::TlsError;
 use p256::ecdh::{EphemeralSecret, SharedSecret};
 use p256::PublicKey;
-use sha2::Digest;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -21,12 +20,6 @@ pub struct ServerHello<'a> {
 }
 
 impl<'a> ServerHello<'a> {
-    pub fn read<D: Digest>(buf: &'a [u8], digest: &mut D) -> Result<ServerHello<'a>, TlsError> {
-        //trace!("server hello hash [{:x?}]", &buf[..]);
-        digest.update(buf);
-        Self::parse(&mut ParseBuffer::new(buf))
-    }
-
     pub fn parse(buf: &mut ParseBuffer<'a>) -> Result<ServerHello<'a>, TlsError> {
         //let mut buf = ParseBuffer::new(&buf[0..content_length]);
         //let mut buf = ParseBuffer::new(&buf);

--- a/src/handshake/server_hello.rs
+++ b/src/handshake/server_hello.rs
@@ -16,7 +16,7 @@ pub struct ServerHello<'a> {
     random: Random,
     legacy_session_id_echo: &'a [u8],
     cipher_suite: CipherSuite,
-    extensions: Vec<ServerHelloExtension<'a>, 16>,
+    extensions: Vec<ServerHelloExtension<'a>, 4>,
 }
 
 impl<'a> ServerHello<'a> {

--- a/src/handshake/server_hello.rs
+++ b/src/handshake/server_hello.rs
@@ -40,8 +40,7 @@ impl<'a> ServerHello<'a> {
             .map_err(|_| TlsError::InvalidSessionIdLength)?;
         //info!("sh 2");
 
-        let cipher_suite = buf.read_u16().map_err(|_| TlsError::InvalidCipherSuite)?;
-        let cipher_suite = CipherSuite::of(cipher_suite).ok_or(TlsError::InvalidCipherSuite)?;
+        let cipher_suite = CipherSuite::parse(buf).map_err(|_| TlsError::InvalidCipherSuite)?;
 
         ////info!("sh 3");
         // skip compression method, it's 0.

--- a/src/record.rs
+++ b/src/record.rs
@@ -59,7 +59,7 @@ impl ClientRecordHeader {
     pub fn trailer_content_type(&self) -> ContentType {
         match self {
             Self::Handshake(_) => ContentType::Handshake,
-            Self::Alert(_) => ContentType::ChangeCipherSpec,
+            Self::Alert(_) => ContentType::Alert,
             Self::ChangeCipherSpec(_) => ContentType::ChangeCipherSpec,
             Self::ApplicationData => ContentType::ApplicationData,
         }

--- a/src/record_reader.rs
+++ b/src/record_reader.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::key_schedule::{HashOutputSize, ReadKeySchedule};
+use crate::key_schedule::ReadKeySchedule;
 use embedded_io::{blocking::Read as BlockingRead, Error};
 
 #[cfg(feature = "async")]
@@ -14,7 +14,7 @@ use crate::{
 
 pub struct RecordReader<'a, CipherSuite>
 where
-    CipherSuite: TlsCipherSuite + 'static,
+    CipherSuite: TlsCipherSuite,
 {
     pub(crate) buf: &'a mut [u8],
     /// The number of decoded bytes in the buffer
@@ -26,7 +26,7 @@ where
 
 impl<'a, CipherSuite> RecordReader<'a, CipherSuite>
 where
-    CipherSuite: TlsCipherSuite + 'static,
+    CipherSuite: TlsCipherSuite,
 {
     pub fn new(buf: &'a mut [u8]) -> Self {
         Self {
@@ -42,10 +42,7 @@ where
         &'m mut self,
         transport: &mut impl AsyncRead,
         key_schedule: &mut ReadKeySchedule<CipherSuite>,
-    ) -> Result<ServerRecord<'m, HashOutputSize<CipherSuite>>, TlsError>
-    where
-        CipherSuite: TlsCipherSuite + 'static,
-    {
+    ) -> Result<ServerRecord<'m, CipherSuite>, TlsError> {
         let header = self.advance(transport, 5).await?;
         let header = RecordHeader::decode(header.try_into().unwrap())?;
 
@@ -83,10 +80,7 @@ where
         &'m mut self,
         transport: &mut impl BlockingRead,
         key_schedule: &mut ReadKeySchedule<CipherSuite>,
-    ) -> Result<ServerRecord<'m, HashOutputSize<CipherSuite>>, TlsError>
-    where
-        CipherSuite: TlsCipherSuite + 'static,
-    {
+    ) -> Result<ServerRecord<'m, CipherSuite>, TlsError> {
         let header = self.advance_blocking(transport, 5)?;
         let header = RecordHeader::decode(header.try_into().unwrap())?;
 


### PR DESCRIPTION
This PR is an attempt to simplify server handshake parsing, and includes a bunch of Digest -> CipherSuite replacements which turn out to simplify the API a bit.

The motivation is two-fold:
 - I'm trying to handle HelloRetryRequests properly (it's a ServerHello, except not entirely, as the specified set of extensions differ and I think clients are supposed to handle them differently)
 - I'm trying to understand record coalescing, without much success yet :)