### PR TITLE
Fix coalesced handshake hashing, again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Correctly handle transcript of coalesced records, attempt 2.
+
 ## 0.14.0 - 2023-04-29
 
 - Refactoring and improving API.
 - Support splitting read and write of a connection.
 - Properly flush write buffer after handshake.
 - Implement BufRead traits for connections.
-- Better handling of protocol violations and unsupported features. 
+- Better handling of protocol violations and unsupported features.
 - Correctly handle transcript of coalesced records.

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -187,15 +187,15 @@ impl<'a, CipherSuite: TlsCipherSuite> ServerHandshake<'a, CipherSuite> {
         buf: &mut ParseBuffer<'a>,
         digest: &mut CipherSuite::Hash,
     ) -> Result<Self, TlsError> {
-        let len = buf.remaining();
+        let handshake_start = buf.offset();
         let mut handshake = Self::parse(buf)?;
-        let consumed = len - buf.remaining();
+        let handshake_end = buf.offset();
 
         if let ServerHandshake::Finished(finished) = &mut handshake {
             finished.hash.replace(digest.clone().finalize());
         }
 
-        digest.update(&buf.as_slice()[0..consumed]);
+        digest.update(&buf.as_slice()[handshake_start..handshake_end]);
 
         Ok(handshake)
     }

--- a/src/parse_buffer.rs
+++ b/src/parse_buffer.rs
@@ -39,6 +39,10 @@ impl<'b> ParseBuffer<'b> {
         self.buffer.len() - self.pos
     }
 
+    pub fn offset(&self) -> usize {
+        self.pos
+    }
+
     pub fn as_slice(&self) -> &'b [u8] {
         self.buffer
     }


### PR DESCRIPTION
Unfortunately, rustls doesn't coalesce handshake messages, or at least not in our current test suite. This meant that the last refactor (#114) silently broke #75 again. This PR fixes the issue.