### PR TITLE
Discard unknown extensions

### DIFF
--- a/src/extensions/extension_group_macro.rs
+++ b/src/extensions/extension_group_macro.rs
@@ -24,7 +24,12 @@ macro_rules! extension_group {
             }
 
             pub fn parse(buf: &mut crate::parse_buffer::ParseBuffer$(<$lt>)?) -> Result<Self, crate::TlsError> {
-                let ext_type = crate::extensions::ExtensionType::parse(buf).map_err(|err| {
+                // Consume extension data even if we don't recognize the extension
+                let extension_type = crate::extensions::ExtensionType::parse(buf);
+                let data_len = buf.read_u16().map_err(|_| crate::TlsError::DecodeError)? as usize;
+                let mut ext_data = buf.slice(data_len).map_err(|_| crate::TlsError::DecodeError)?;
+
+                let ext_type = extension_type.map_err(|err| {
                     warn!("Failed to read extension type: {:?}", err);
                     match err {
                         crate::parse_buffer::ParseError::InvalidData => crate::TlsError::UnknownExtensionType,
@@ -33,12 +38,7 @@ macro_rules! extension_group {
                 })?;
 
                 debug!("Read extension type {:?}", ext_type);
-
-                let data_len = buf.read_u16().map_err(|_| crate::TlsError::DecodeError)? as usize;
-
                 trace!("Extension data length: {}", data_len);
-
-                let mut ext_data = buf.slice(data_len).map_err(|_| crate::TlsError::DecodeError)?;
 
                 match ext_type {
                     $(crate::extensions::ExtensionType::$extension => Ok(Self::$extension(<$extension_data>::parse(&mut ext_data).map_err(|err| {
@@ -74,6 +74,7 @@ macro_rules! extension_group {
                 let mut extensions = heapless::Vec::new();
 
                 while !ext_buf.is_empty() {
+                    trace!("Extension buffer: {}", ext_buf.remaining());
                     match Self::parse(&mut ext_buf) {
                         Ok(extension) => {
                             extensions
@@ -87,6 +88,7 @@ macro_rules! extension_group {
                     }
                 }
 
+                trace!("Read {} extensions", extensions.len());
                 Ok(extensions)
             }
         }

--- a/src/extensions/extension_group_macro.rs
+++ b/src/extensions/extension_group_macro.rs
@@ -35,6 +35,9 @@ macro_rules! extension_group {
                 debug!("Read extension type {:?}", ext_type);
 
                 let data_len = buf.read_u16().map_err(|_| crate::TlsError::DecodeError)? as usize;
+
+                trace!("Extension data length: {}", data_len);
+
                 let mut ext_data = buf.slice(data_len).map_err(|_| crate::TlsError::DecodeError)?;
 
                 match ext_type {

--- a/src/handshake/new_session_ticket.rs
+++ b/src/handshake/new_session_ticket.rs
@@ -1,7 +1,6 @@
 use heapless::Vec;
 
 use crate::extensions::messages::NewSessionTicketExtension;
-use crate::extensions::ExtensionType;
 use crate::parse_buffer::ParseBuffer;
 use crate::TlsError;
 
@@ -16,9 +15,6 @@ pub struct NewSessionTicket<'a> {
 }
 
 impl<'a> NewSessionTicket<'a> {
-    // Source: https://www.rfc-editor.org/rfc/rfc8446#section-4.2 table, rows marked with NST
-    const ALLOWED_EXTENSIONS: &[ExtensionType] = &[ExtensionType::EarlyData];
-
     pub fn parse(buf: &mut ParseBuffer<'a>) -> Result<NewSessionTicket<'a>, TlsError> {
         let lifetime = buf.read_u32()?;
         let age_add = buf.read_u32()?;


### PR DESCRIPTION
Google seems to send a random extension in the NewSessionTicket handshake. Spec says that we need to discard these:

[4.6.1](https://www.rfc-editor.org/rfc/rfc8446#section-4.6.1).  New Session Ticket Message

> extensions:  A set of extension values for the ticket.  The
>      "Extension" format is defined in [Section 4.2](https://www.rfc-editor.org/rfc/rfc8446#section-4.2).  Clients MUST ignore
>      unrecognized extensions.

In theory, we currently ignore unknown extensions anyway, so we shouldn't have failed on this. However, the parser short circuited when it encountered an unknown extension, and left the extension data unconsumed. This means that following loop iterations might have encountered data they couldn't parse. This PR correctly consumes extension data to prevent these issues.

Log output of the relevant test:

```
[2023-05-09T10:54:42Z INFO  client_test] Established
[2023-05-09T10:54:42Z DEBUG embedded_tls::write_buffer] start_record(ApplicationData)
[2023-05-09T10:54:42Z TRACE embedded_tls::connection] output size 35
[2023-05-09T10:54:42Z TRACE embedded_tls::connection] Decrypting: content type = Handshake
[2023-05-09T10:54:42Z TRACE embedded_tls::handshake] handshake = NewSessionTicket
[2023-05-09T10:54:42Z TRACE embedded_tls::extensions::messages] Extension buffer: 12
[2023-05-09T10:54:42Z DEBUG embedded_tls::extensions::messages] Read extension type EarlyData
[2023-05-09T10:54:42Z TRACE embedded_tls::extensions::messages] Extension data length: 4
[2023-05-09T10:54:42Z TRACE embedded_tls::extensions::messages] Extension buffer: 4
[2023-05-09T10:54:42Z WARN  embedded_tls::extensions] Read unknown ExtensionType: 56026
[2023-05-09T10:54:42Z WARN  embedded_tls::extensions::messages] Failed to read extension type: InvalidData
[2023-05-09T10:54:42Z TRACE embedded_tls::extensions::messages] Read 1 extensions
[2023-05-09T10:54:42Z TRACE embedded_tls::handshake] handshake = NewSessionTicket
[2023-05-09T10:54:42Z TRACE embedded_tls::extensions::messages] Extension buffer: 12
[2023-05-09T10:54:42Z DEBUG embedded_tls::extensions::messages] Read extension type EarlyData
[2023-05-09T10:54:42Z TRACE embedded_tls::extensions::messages] Extension data length: 4
[2023-05-09T10:54:42Z TRACE embedded_tls::extensions::messages] Extension buffer: 4
[2023-05-09T10:54:42Z WARN  embedded_tls::extensions] Read unknown ExtensionType: 56026
[2023-05-09T10:54:42Z WARN  embedded_tls::extensions::messages] Failed to read extension type: InvalidData
[2023-05-09T10:54:42Z TRACE embedded_tls::extensions::messages] Read 1 extensions
[2023-05-09T10:54:42Z TRACE embedded_tls::connection] Decrypting: content type = ApplicationData
[2023-05-09T10:54:42Z TRACE embedded_tls::asynch] Copied 1378 bytes
[2023-05-09T10:54:42Z INFO  client_test] Read 1378 bytes: [buffer omitted]
```

Closes #119