### PR TITLE
Increment decrypt_consumed instead of assigning

### DIFF
--- a/src/read_buffer.rs
+++ b/src/read_buffer.rs
@@ -84,7 +84,7 @@ impl<'a> ReadBuffer<'a> {
 impl Drop for ReadBuffer<'_> {
     #[inline]
     fn drop(&mut self) {
-        *self.decrypted_consumed = if self.used {
+        *self.decrypted_consumed += if self.used {
             self.consumed
         } else {
             // Consume all if dropped unused
@@ -99,12 +99,12 @@ mod test {
 
     #[test]
     fn dropping_unused_buffer_consumes_all() {
-        let mut consumed = 0;
+        let mut consumed = 1000;
         let buffer = [0, 1, 2, 3];
 
         _ = ReadBuffer::new(&buffer, &mut consumed);
 
-        assert_eq!(consumed, 4);
+        assert_eq!(consumed, 1004);
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes a regression when calling TlsConnection::read() multiple times on the same record buffer. For each call to read, the total number of consumed bytes should be incremented, and not assigned to the most recent value.