### PR TITLE
Fix blocking when reading into empty buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.16.3 - ?
+
+- Don't block when reading into an empty buffer
+
 ## 0.16.2 - 2023-11-02
 
 - Re-add `impl_trait_projections` to support older nightly rustc versions

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -163,6 +163,9 @@ where
 
     /// Read and decrypt data filling the provided slice.
     pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize, TlsError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let mut buffer = self.read_buffered().await?;
 
         let len = buffer.pop_into(buf);
@@ -460,6 +463,9 @@ where
     State: SplitState,
 {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let mut buffer = self.read_buffered().await?;
 
         let len = buffer.pop_into(buf);

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -156,6 +156,9 @@ where
 
     /// Read and decrypt data filling the provided slice.
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, TlsError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let mut buffer = self.read_buffered()?;
 
         let len = buffer.pop_into(buf);
@@ -450,6 +453,9 @@ where
     State: SplitState,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let mut buffer = self.read_buffered()?;
 
         let len = buffer.pop_into(buf);

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -140,6 +140,11 @@ async fn test_ping() {
     assert_eq!(b"ping", &rx_buf[..sz]);
     log::info!("Read {} bytes: {:?}", sz, &rx_buf[..sz]);
 
+    // Test that embedded-tls doesn't block if the buffer is empty.
+    let mut rx_buf = [0; 0];
+    let sz = tls.read(&mut rx_buf).await.expect("error reading data");
+    assert_eq!(sz, 0);
+
     tls.close()
         .await
         .map_err(|(_, e)| e)
@@ -303,6 +308,11 @@ fn test_blocking_ping() {
     assert_eq!(4, sz);
     assert_eq!(b"ping", &rx_buf[..sz]);
     log::info!("Read {} bytes: {:?}", sz, &rx_buf[..sz]);
+
+    // Test that embedded-tls doesn't block if the buffer is empty.
+    let mut rx_buf = [0; 0];
+    let sz = tls.read(&mut rx_buf).expect("error reading data");
+    assert_eq!(sz, 0);
 
     tls.close()
         .map_err(|(_, e)| e)


### PR DESCRIPTION
[`embedded_io::Read`](https://docs.rs/embedded-io/0.6.1/embedded_io/trait.Read.html#tymethod.read) specifies that reading into an empty buffer does not block.

> If buf.len() == 0, read returns without blocking, with either Ok(0) or an error. The Ok(0) doesn’t indicate EOF, unlike when called with a non-empty buffer.

We implemented `read` in terms of the semantics of `BufRead` which blocks if there are no bytes available. This is incorrect in that we need to check if we actually have to wait for any bytes to be loaded.