### PR TITLE
Allow both defmt and log to be used at the same time

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,9 +1,6 @@
 #![macro_use]
 #![allow(unused_macros)]
 
-#[cfg(all(feature = "defmt", feature = "log"))]
-compile_error!("You may not enable both `defmt` and `log` features.");
-
 macro_rules! assert {
     ($($x:tt)*) => {
         {


### PR DESCRIPTION
When both are enabled it will emit to both, but prefer defmt for assertions.