### PR TITLE
feat: derive `Clone` for `TlsConfig`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -119,7 +119,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TlsConfig<'a> {
     pub(crate) server_name: Option<&'a str>,


### PR DESCRIPTION
Derives the `Clone` trait for `TlsConfig`. This may be useful to library consumers.