### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -253,6 +253,7 @@ where
         self.split_with(ManagedSplitState::new())
     }
 
+    #[allow(clippy::type_complexity)] // Requires inherent type aliases to solve well.
     pub fn split_with<StateContainer>(
         self,
         state: StateContainer,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -69,10 +69,7 @@ where
     ///
     /// Returns an error if the handshake does not proceed. If an error occurs, the connection
     /// instance must be recreated.
-    pub fn open<'v, Provider>(
-        &mut self,
-        mut context: TlsContext<'v, Provider>,
-    ) -> Result<(), TlsError>
+    pub fn open<Provider>(&mut self, mut context: TlsContext<Provider>) -> Result<(), TlsError>
     where
         Provider: CryptoProvider<CipherSuite = CipherSuite>,
     {
@@ -244,6 +241,7 @@ where
         self.split_with(ManagedSplitState::new())
     }
 
+    #[allow(clippy::type_complexity)] // Requires inherent type aliases to solve well.
     pub fn split_with<StateContainer>(
         self,
         state: StateContainer,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -137,7 +137,7 @@ where
     certificate_request: Option<CertificateRequest>,
 }
 
-impl<'v, CipherSuite> Handshake<CipherSuite>
+impl<CipherSuite> Handshake<CipherSuite>
 where
     CipherSuite: TlsCipherSuite,
 {
@@ -437,10 +437,10 @@ where
     }
 }
 
-fn process_server_verify<'a, 'v, Provider>(
+fn process_server_verify<Provider>(
     handshake: &mut Handshake<Provider::CipherSuite>,
     key_schedule: &mut KeySchedule<Provider::CipherSuite>,
-    config: &TlsConfig<'a>,
+    config: &TlsConfig<'_>,
     crypto_provider: &mut Provider,
     record: ServerRecord<'_, Provider::CipherSuite>,
 ) -> Result<State, TlsError>

--- a/src/handshake/certificate.rs
+++ b/src/handshake/certificate.rs
@@ -100,12 +100,12 @@ impl<'a> CertificateEntryRef<'a> {
     }
 
     pub(crate) fn encode(&self, buf: &mut CryptoBuffer<'_>) -> Result<(), TlsError> {
-        match self {
-            &CertificateEntryRef::RawPublicKey(_key) => {
+        match *self {
+            CertificateEntryRef::RawPublicKey(_key) => {
                 todo!("ASN1_subjectPublicKeyInfo encoding?");
                 // buf.with_u24_length(|buf| buf.extend_from_slice(key))?;
             }
-            &CertificateEntryRef::X509(cert) => {
+            CertificateEntryRef::X509(cert) => {
                 buf.with_u24_length(|buf| buf.extend_from_slice(cert))?;
             }
         }

--- a/src/record_reader.rs
+++ b/src/record_reader.rs
@@ -72,8 +72,8 @@ impl<'a> RecordReader<'a> {
         self.consume(header, key_schedule.transcript_hash())
     }
 
-    fn advance_blocking<'m>(
-        &'m mut self,
+    fn advance_blocking(
+        &mut self,
         transport: &mut impl BlockingRead,
         amount: usize,
     ) -> Result<(), TlsError> {

--- a/tests/psk_test.rs
+++ b/tests/psk_test.rs
@@ -54,7 +54,7 @@ fn setup() -> (SocketAddr, JoinHandle<()>) {
         let mut conn = acceptor.accept(stream).unwrap();
         let mut buf = [0; 64];
         let len = conn.read(&mut buf[..]).unwrap();
-        conn.write(&buf[..len]).unwrap();
+        conn.write_all(&buf[..len]).unwrap();
     });
     (addr, h)
 }

--- a/tests/tlsserver.rs
+++ b/tests/tlsserver.rs
@@ -240,7 +240,7 @@ impl Connection {
         // If we have a successful but empty read, that's an EOF.
         // Otherwise, we shove the data into the TLS session.
         match maybe_len {
-            Some(len) if len == 0 => {
+            Some(0) => {
                 log::debug!("back eof");
                 self.closing = true;
             }


### PR DESCRIPTION
This leaves one clippy warning, `large_enum_variant`, triggered by `ServerHandshake`, but I'm opening a followup to fix that.