### PR TITLE
Shrink the size of CertificateRequestExtension::SignatureAlgorithms

### DIFF
--- a/src/extensions/extension_data/signature_algorithms.rs
+++ b/src/extensions/extension_data/signature_algorithms.rs
@@ -10,36 +10,36 @@ use heapless::Vec;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SignatureScheme {
     /* RSASSA-PKCS1-v1_5 algorithms */
-    RsaPkcs1Sha256 = 0x0401,
-    RsaPkcs1Sha384 = 0x0501,
-    RsaPkcs1Sha512 = 0x0601,
+    RsaPkcs1Sha256,
+    RsaPkcs1Sha384,
+    RsaPkcs1Sha512,
 
     /* ECDSA algorithms */
-    EcdsaSecp256r1Sha256 = 0x0403,
-    EcdsaSecp384r1Sha384 = 0x0503,
-    EcdsaSecp521r1Sha512 = 0x0603,
+    EcdsaSecp256r1Sha256,
+    EcdsaSecp384r1Sha384,
+    EcdsaSecp521r1Sha512,
 
     /* RSASSA-PSS algorithms with public key OID rsaEncryption */
-    RsaPssRsaeSha256 = 0x0804,
-    RsaPssRsaeSha384 = 0x0805,
-    RsaPssRsaeSha512 = 0x0806,
+    RsaPssRsaeSha256,
+    RsaPssRsaeSha384,
+    RsaPssRsaeSha512,
 
     /* EdDSA algorithms */
-    Ed25519 = 0x0807,
-    Ed448 = 0x0808,
+    Ed25519,
+    Ed448,
 
     /* RSASSA-PSS algorithms with public key OID RSASSA-PSS */
-    RsaPssPssSha256 = 0x0809,
-    RsaPssPssSha384 = 0x080a,
-    RsaPssPssSha512 = 0x080b,
+    RsaPssPssSha256,
+    RsaPssPssSha384,
+    RsaPssPssSha512,
 
-    Sha224Ecdsa = 0x0303,
-    Sha224Rsa = 0x0301,
-    Sha224Dsa = 0x0302,
+    Sha224Ecdsa,
+    Sha224Rsa,
+    Sha224Dsa,
 
     /* Legacy algorithms */
-    RsaPkcs1Sha1 = 0x0201,
-    EcdsaSha1 = 0x0203,
+    RsaPkcs1Sha1,
+    EcdsaSha1,
     /* Reserved Code Points */
     //private_use(0xFE00..0xFFFF),
     //(0xFFFF)
@@ -76,6 +76,36 @@ impl SignatureScheme {
             _ => Err(ParseError::InvalidData),
         }
     }
+
+    pub fn as_u16(self) -> u16 {
+        match self {
+            Self::RsaPkcs1Sha256 => 0x0401,
+            Self::RsaPkcs1Sha384 => 0x0501,
+            Self::RsaPkcs1Sha512 => 0x0601,
+
+            Self::EcdsaSecp256r1Sha256 => 0x0403,
+            Self::EcdsaSecp384r1Sha384 => 0x0503,
+            Self::EcdsaSecp521r1Sha512 => 0x0603,
+
+            Self::RsaPssRsaeSha256 => 0x0804,
+            Self::RsaPssRsaeSha384 => 0x0805,
+            Self::RsaPssRsaeSha512 => 0x0806,
+
+            Self::Ed25519 => 0x0807,
+            Self::Ed448 => 0x0808,
+
+            Self::RsaPssPssSha256 => 0x0809,
+            Self::RsaPssPssSha384 => 0x080a,
+            Self::RsaPssPssSha512 => 0x080b,
+
+            Self::Sha224Ecdsa => 0x0303,
+            Self::Sha224Rsa => 0x0301,
+            Self::Sha224Dsa => 0x0302,
+
+            Self::RsaPkcs1Sha1 => 0x0201,
+            Self::EcdsaSha1 => 0x0203,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -97,7 +127,8 @@ impl<const N: usize> SignatureAlgorithms<N> {
     pub fn encode(&self, buf: &mut CryptoBuffer) -> Result<(), TlsError> {
         buf.with_u16_length(|buf| {
             for &a in self.supported_signature_algorithms.iter() {
-                buf.push_u16(a as u16).map_err(|_| TlsError::EncodeError)?;
+                buf.push_u16(a.as_u16())
+                    .map_err(|_| TlsError::EncodeError)?;
             }
             Ok(())
         })

--- a/src/extensions/extension_data/signature_algorithms_cert.rs
+++ b/src/extensions/extension_data/signature_algorithms_cert.rs
@@ -25,7 +25,8 @@ impl<const N: usize> SignatureAlgorithmsCert<N> {
     pub fn encode(&self, buf: &mut CryptoBuffer) -> Result<(), TlsError> {
         buf.with_u16_length(|buf| {
             for &a in self.supported_signature_algorithms.iter() {
-                buf.push_u16(a as u16).map_err(|_| TlsError::EncodeError)?;
+                buf.push_u16(a.as_u16())
+                    .map_err(|_| TlsError::EncodeError)?;
             }
             Ok(())
         })

--- a/src/handshake/certificate_verify.rs
+++ b/src/handshake/certificate_verify.rs
@@ -37,7 +37,7 @@ pub struct CertificateVerify {
 
 impl CertificateVerify {
     pub(crate) fn encode(&self, buf: &mut CryptoBuffer<'_>) -> Result<(), TlsError> {
-        buf.push_u16(self.signature_scheme as _)?;
+        buf.push_u16(self.signature_scheme.as_u16())?;
         buf.with_u16_length(|buf| buf.extend_from_slice(self.signature.as_slice()))?;
         Ok(())
     }


### PR DESCRIPTION
This uses the same trick as #146, shrinking `CertificateRequestExtension` from `48` bytes to `28`.