### PR TITLE
Remove dead fields/code which bloat type sizes

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -9,6 +9,7 @@ pub struct CryptoBuffer<'b> {
 }
 
 impl<'b> CryptoBuffer<'b> {
+    #[allow(dead_code)]
     pub(crate) fn empty() -> Self {
         Self {
             buf: &mut [],

--- a/src/change_cipher_spec.rs
+++ b/src/change_cipher_spec.rs
@@ -21,6 +21,7 @@ impl ChangeCipherSpec {
         Ok(Self {})
     }
 
+    #[allow(dead_code)]
     pub(crate) fn encode(&self, buf: &mut CryptoBuffer<'_>) -> Result<(), TlsError> {
         buf.push(1).map_err(|_| TlsError::EncodeError)?;
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,6 @@ use typenum::{Sum, U10, U12, U16, U32};
 
 pub use crate::extensions::extension_data::max_fragment_length::MaxFragmentLength;
 
-pub(crate) const TLS_RECORD_MAX: usize = 16384;
 pub const TLS_RECORD_OVERHEAD: usize = 128;
 
 // longest label is 12b -> buf <= 2 + 1 + 6 + longest + 1 + hash_out = hash_out + 22

--- a/src/crypto_engine.rs
+++ b/src/crypto_engine.rs
@@ -2,14 +2,11 @@ use crate::application_data::ApplicationData;
 use crate::extensions::extension_data::supported_groups::NamedGroup;
 use p256::ecdh::SharedSecret;
 
-pub struct CryptoEngine {
-    group: NamedGroup,
-    shared: SharedSecret,
-}
+pub struct CryptoEngine {}
 
 impl CryptoEngine {
-    pub fn new(group: NamedGroup, shared: SharedSecret) -> Self {
-        Self { group, shared }
+    pub fn new(_group: NamedGroup, _shared: SharedSecret) -> Self {
+        Self {}
     }
 
     pub fn decrypt(&self, _: &ApplicationData) {}

--- a/src/handshake/certificate.rs
+++ b/src/handshake/certificate.rs
@@ -131,7 +131,6 @@ impl<'a> From<&crate::config::Certificate<'a>> for CertificateEntryRef<'a> {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Certificate<const N: usize> {
     request_context: Vec<u8, 256>,
-    num_entries: usize,
     entries_data: Vec<u8, N>,
 }
 
@@ -155,7 +154,6 @@ impl<'a, const N: usize> TryFrom<CertificateRef<'a>> for Certificate<N> {
 
         Ok(Self {
             request_context,
-            num_entries: cert.entries.len(),
             entries_data,
         })
     }

--- a/src/handshake/certificate_request.rs
+++ b/src/handshake/certificate_request.rs
@@ -1,14 +1,12 @@
-use crate::extensions::extension_data::signature_algorithms::SignatureAlgorithms;
 use crate::extensions::messages::CertificateRequestExtension;
 use crate::parse_buffer::ParseBuffer;
-use crate::TlsError;
+use crate::{unused, TlsError};
 use heapless::Vec;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CertificateRequestRef<'a> {
     pub(crate) request_context: &'a [u8],
-    pub(crate) extensions: Vec<CertificateRequestExtension<'a>, 6>,
 }
 
 impl<'a> CertificateRequestRef<'a> {
@@ -23,9 +21,9 @@ impl<'a> CertificateRequestRef<'a> {
         // Validate extensions
         let extensions = CertificateRequestExtension::parse_vector::<6>(buf)?;
 
+        unused(extensions);
         Ok(Self {
             request_context: request_context.as_slice(),
-            extensions,
         })
     }
 }
@@ -34,7 +32,6 @@ impl<'a> CertificateRequestRef<'a> {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CertificateRequest {
     pub(crate) request_context: Vec<u8, 256>,
-    pub(crate) signature_algorithms: Option<SignatureAlgorithms<19>>,
 }
 
 impl<'a> TryFrom<CertificateRequestRef<'a>> for CertificateRequest {
@@ -48,17 +45,6 @@ impl<'a> TryFrom<CertificateRequestRef<'a>> for CertificateRequest {
                 TlsError::InsufficientSpace
             })?;
 
-        let mut signature_algorithms = None;
-
-        for ext in cert.extensions {
-            if let CertificateRequestExtension::SignatureAlgorithms(algos) = ext {
-                signature_algorithms = Some(algos)
-            }
-        }
-
-        Ok(Self {
-            request_context,
-            signature_algorithms,
-        })
+        Ok(Self { request_context })
     }
 }

--- a/src/handshake/certificate_verify.rs
+++ b/src/handshake/certificate_verify.rs
@@ -7,8 +7,8 @@ use super::CryptoBuffer;
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CertificateVerifyRef<'a> {
-    pub(crate) signature_scheme: SignatureScheme,
-    pub(crate) signature: &'a [u8],
+    pub signature_scheme: SignatureScheme,
+    pub signature: &'a [u8],
 }
 
 impl<'a> CertificateVerifyRef<'a> {

--- a/src/handshake/encrypted_extensions.rs
+++ b/src/handshake/encrypted_extensions.rs
@@ -1,17 +1,19 @@
+use core::marker::PhantomData;
+
 use crate::extensions::messages::EncryptedExtensionsExtension;
 
 use crate::parse_buffer::ParseBuffer;
 use crate::TlsError;
-use heapless::Vec;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct EncryptedExtensions<'a> {
-    extensions: Vec<EncryptedExtensionsExtension<'a>, 16>,
+    _todo: PhantomData<&'a ()>,
 }
 
 impl<'a> EncryptedExtensions<'a> {
     pub fn parse(buf: &mut ParseBuffer<'a>) -> Result<EncryptedExtensions<'a>, TlsError> {
-        EncryptedExtensionsExtension::parse_vector(buf).map(|extensions| Self { extensions })
+        EncryptedExtensionsExtension::parse_vector::<16>(buf)?;
+        Ok(EncryptedExtensions { _todo: PhantomData })
     }
 }

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -131,6 +131,7 @@ where
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum ServerHandshake<'a, CipherSuite: TlsCipherSuite> {
     ServerHello(ServerHello<'a>),
     EncryptedExtensions(EncryptedExtensions<'a>),

--- a/src/handshake/new_session_ticket.rs
+++ b/src/handshake/new_session_ticket.rs
@@ -1,17 +1,13 @@
-use heapless::Vec;
+use core::marker::PhantomData;
 
 use crate::extensions::messages::NewSessionTicketExtension;
 use crate::parse_buffer::ParseBuffer;
-use crate::TlsError;
+use crate::{unused, TlsError};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NewSessionTicket<'a> {
-    lifetime: u32,
-    age_add: u32,
-    nonce: &'a [u8],
-    ticket: &'a [u8],
-    extensions: Vec<NewSessionTicketExtension<'a>, 1>,
+    _todo: PhantomData<&'a ()>,
 }
 
 impl<'a> NewSessionTicket<'a> {
@@ -29,14 +25,9 @@ impl<'a> NewSessionTicket<'a> {
             .slice(ticket_length as usize)
             .map_err(|_| TlsError::InvalidTicketLength)?;
 
-        let extensions = NewSessionTicketExtension::parse_vector(buf)?;
+        let extensions = NewSessionTicketExtension::parse_vector::<1>(buf)?;
 
-        Ok(Self {
-            lifetime,
-            age_add,
-            nonce: nonce.as_slice(),
-            ticket: ticket.as_slice(),
-            extensions,
-        })
+        unused((lifetime, age_add, nonce, ticket, extensions));
+        Ok(Self { _todo: PhantomData })
     }
 }

--- a/src/handshake/server_hello.rs
+++ b/src/handshake/server_hello.rs
@@ -4,18 +4,14 @@ use crate::cipher_suites::CipherSuite;
 use crate::crypto_engine::CryptoEngine;
 use crate::extensions::extension_data::key_share::KeyShareEntry;
 use crate::extensions::messages::ServerHelloExtension;
-use crate::handshake::Random;
 use crate::parse_buffer::ParseBuffer;
-use crate::TlsError;
+use crate::{unused, TlsError};
 use p256::ecdh::{EphemeralSecret, SharedSecret};
 use p256::PublicKey;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ServerHello<'a> {
-    random: Random,
-    legacy_session_id_echo: &'a [u8],
-    cipher_suite: CipherSuite,
     extensions: Vec<ServerHelloExtension<'a>, 4>,
 }
 
@@ -53,12 +49,8 @@ impl<'a> ServerHello<'a> {
         debug!("server cipher_suite {:?}", cipher_suite);
         debug!("server extensions {:?}", extensions);
 
-        Ok(Self {
-            random,
-            legacy_session_id_echo: session_id.as_slice(),
-            cipher_suite,
-            extensions,
-        })
+        unused(session_id);
+        Ok(Self { extensions })
     }
 
     pub fn key_share(&self) -> Option<&KeyShareEntry> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![doc = include_str!("../README.md")]
-#![allow(dead_code)]
 
 /*!
 # Example
@@ -143,3 +142,8 @@ mod stdlib {
         }
     }
 }
+
+/// An internal function to mark an unused value.
+///
+/// All calls to this should be removed before 1.x.
+fn unused<T>(_: T) {}


### PR DESCRIPTION
This removes unread fields which unnecessarily cause type (and therefore stack) sizes to increase.