### PR TITLE
Added additional info to read_list error.

### DIFF
--- a/src/application_data.rs
+++ b/src/application_data.rs
@@ -7,7 +7,7 @@ pub struct ApplicationData<'a> {
     pub(crate) data: CryptoBuffer<'a>,
 }
 
-impl<'a> Debug for ApplicationData<'a> {
+impl Debug for ApplicationData<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "ApplicationData {:x?}", self.data.len())
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -217,19 +217,19 @@ impl<'b> CryptoBuffer<'b> {
     }
 }
 
-impl<'b> AsRef<[u8]> for CryptoBuffer<'b> {
+impl AsRef<[u8]> for CryptoBuffer<'_> {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
     }
 }
 
-impl<'b> AsMut<[u8]> for CryptoBuffer<'b> {
+impl AsMut<[u8]> for CryptoBuffer<'_> {
     fn as_mut(&mut self) -> &mut [u8] {
         self.as_mut_slice()
     }
 }
 
-impl<'b> Buffer for CryptoBuffer<'b> {
+impl Buffer for CryptoBuffer<'_> {
     fn extend_from_slice(&mut self, other: &[u8]) -> Result<(), Error> {
         self.extend_internal(other).map_err(|_| Error)
     }

--- a/src/change_cipher_spec.rs
+++ b/src/change_cipher_spec.rs
@@ -18,6 +18,7 @@ impl ChangeCipherSpec {
         Ok(Self {})
     }
 
+    #[allow(dead_code)]
     pub fn parse(_: &mut ParseBuffer) -> Result<Self, TlsError> {
         Ok(Self {})
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -373,7 +373,7 @@ impl<'a> TlsConfig<'a> {
     }
 }
 
-impl<'a> Default for TlsConfig<'a> {
+impl Default for TlsConfig<'_> {
     fn default() -> Self {
         TlsConfig::new()
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -340,11 +340,11 @@ where
     Ok(())
 }
 
-async fn handle_processing_error<'a, CipherSuite>(
+async fn handle_processing_error<CipherSuite>(
     result: Result<State, TlsError>,
     transport: &mut impl AsyncWrite,
     key_schedule: &mut KeySchedule<CipherSuite>,
-    tx_buf: &mut WriteBuffer<'a>,
+    tx_buf: &mut WriteBuffer<'_>,
 ) -> Result<State, TlsError>
 where
     CipherSuite: TlsCipherSuite,

--- a/src/crypto_engine.rs
+++ b/src/crypto_engine.rs
@@ -2,9 +2,10 @@ use crate::application_data::ApplicationData;
 use crate::extensions::extension_data::supported_groups::NamedGroup;
 use p256::ecdh::SharedSecret;
 
+#[allow(dead_code)]
 pub struct CryptoEngine {}
 
-#[allow(clippy::unused_self, clippy::needless_pass_by_value)] // TODO
+#[allow(clippy::unused_self, clippy::needless_pass_by_value, dead_code)] // TODO
 impl CryptoEngine {
     pub fn new(_group: NamedGroup, _shared: SharedSecret) -> Self {
         Self {}

--- a/src/handshake/mod.rs
+++ b/src/handshake/mod.rs
@@ -75,7 +75,7 @@ where
     Finished(Finished<HashOutputSize<CipherSuite>>),
 }
 
-impl<'config, 'a, CipherSuite> ClientHandshake<'config, 'a, CipherSuite>
+impl<CipherSuite> ClientHandshake<'_, '_, CipherSuite>
 where
     CipherSuite: TlsCipherSuite,
 {
@@ -137,7 +137,7 @@ pub enum ServerHandshake<'a, CipherSuite: TlsCipherSuite> {
     Finished(Finished<HashOutputSize<CipherSuite>>),
 }
 
-impl<'a, CipherSuite: TlsCipherSuite> ServerHandshake<'a, CipherSuite> {
+impl<CipherSuite: TlsCipherSuite> ServerHandshake<'_, CipherSuite> {
     pub fn handshake_type(&self) -> HandshakeType {
         match self {
             ServerHandshake::ServerHello(_) => HandshakeType::ServerHello,
@@ -151,7 +151,7 @@ impl<'a, CipherSuite: TlsCipherSuite> ServerHandshake<'a, CipherSuite> {
     }
 }
 
-impl<'a, CipherSuite: TlsCipherSuite> Debug for ServerHandshake<'a, CipherSuite> {
+impl<CipherSuite: TlsCipherSuite> Debug for ServerHandshake<'_, CipherSuite> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             ServerHandshake::ServerHello(inner) => Debug::fmt(inner, f),

--- a/src/parse_buffer.rs
+++ b/src/parse_buffer.rs
@@ -157,7 +157,11 @@ impl<'b> ParseBuffer<'b> {
         let mut data = self.slice(data_length)?;
         while !data.is_empty() {
             result.push(read(&mut data)?).map_err(|_| {
-                error!("Failed to store parse result");
+                error!(
+                    "Failed to store parse result. Type: {} Parsed: {}",
+                    core::any::type_name::<T>(),
+                    N
+                );
                 ParseError::InsufficientSpace
             })?;
         }

--- a/src/record.rs
+++ b/src/record.rs
@@ -78,7 +78,7 @@ impl ClientRecordHeader {
     }
 }
 
-impl<'config, 'a, CipherSuite> ClientRecord<'config, 'a, CipherSuite>
+impl<'config, CipherSuite> ClientRecord<'config, '_, CipherSuite>
 where
     //N: ArrayLength<u8>,
     CipherSuite: TlsCipherSuite,

--- a/src/record_reader.rs
+++ b/src/record_reader.rs
@@ -35,7 +35,7 @@ impl<'a> RecordReader<'a> {
             pending: 0,
         }
     }
-    pub fn reborrow_mut<'b>(&'b mut self) -> RecordReaderBorrowMut<'b> {
+    pub fn reborrow_mut(&mut self) -> RecordReaderBorrowMut<'_> {
         RecordReaderBorrowMut {
             buf: self.buf,
             decoded: &mut self.decoded,
@@ -71,7 +71,7 @@ impl<'a> RecordReader<'a> {
     }
 }
 
-impl<'a> RecordReaderBorrowMut<'a> {
+impl RecordReaderBorrowMut<'_> {
     pub async fn read<'m, CipherSuite: TlsCipherSuite>(
         &'m mut self,
         transport: &mut impl AsyncRead,
@@ -152,8 +152,8 @@ pub fn read_blocking<'m, CipherSuite: TlsCipherSuite>(
     )
 }
 
-async fn advance<'m>(
-    buf: &'m mut [u8],
+async fn advance(
+    buf: &mut [u8],
     decoded: &mut usize,
     pending: &mut usize,
     transport: &mut impl AsyncRead,
@@ -175,8 +175,8 @@ async fn advance<'m>(
     Ok(())
 }
 
-fn advance_blocking<'m>(
-    buf: &'m mut [u8],
+fn advance_blocking(
+    buf: &mut [u8],
     decoded: &mut usize,
     pending: &mut usize,
     transport: &mut impl BlockingRead,
@@ -218,8 +218,8 @@ fn consume<'m, CipherSuite: TlsCipherSuite>(
     ServerRecord::decode(header, slice, digest)
 }
 
-fn ensure_contiguous<'m>(
-    buf: &'m mut [u8],
+fn ensure_contiguous(
+    buf: &mut [u8],
     decoded: &mut usize,
     pending: &mut usize,
     len: usize,

--- a/src/write_buffer.rs
+++ b/src/write_buffer.rs
@@ -109,7 +109,7 @@ impl<'a> WriteBuffer<'a> {
     }
 }
 
-impl<'a> WriteBufferBorrow<'a> {
+impl WriteBufferBorrow<'_> {
     fn max_block_size(&self) -> usize {
         self.buffer.len() - TLS_RECORD_OVERHEAD
     }
@@ -135,7 +135,7 @@ impl<'a> WriteBufferBorrow<'a> {
     }
 }
 
-impl<'a> WriteBufferBorrowMut<'a> {
+impl WriteBufferBorrowMut<'_> {
     fn reborrow(&self) -> WriteBufferBorrow<'_> {
         WriteBufferBorrow {
             buffer: self.buffer,


### PR DESCRIPTION
Hi, this PR adds additional info to the error message in `ParseBuffer::read_list`, by logging the type and max number of entries. I added this while trying to fix #153, which was difficult, since the error message contained no info about the parsing step that caused the issue. I also took the liberty to let clippy fix a number of warnings.