### PR TITLE
Handle EINTR to avoid crashing tests when debugging

### DIFF
--- a/tests/tlsserver.rs
+++ b/tests/tlsserver.rs
@@ -385,7 +385,13 @@ pub fn run_with_config(mut listener: TcpListener, config: rustls::ServerConfig) 
 
     let mut events = mio::Events::with_capacity(256);
     loop {
-        poll.poll(&mut events, None).unwrap();
+        if let Err(e) = poll.poll(&mut events, None) {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                log::debug!("I/O error {:?}", e);
+                continue;
+            }
+            panic!("I/O error {:?}", e);
+        }
 
         for event in events.iter() {
             match event.token() {


### PR DESCRIPTION
I have experienced that the unit tests crashes when running them with a debugger and stopping at breakpoints. This is inconvenient.

I found out that it is probably the debugger's signal handlers that interferes with the system calls inside Mio as described in the [libc manual](https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html).

The `EINTR` error propagates up to code in `tlsserver.rs` and it seems I can handle this by ignoring that particular error and call `poll()`  again.