### PR TITLE
Add `clippy` to `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
 channel = "1.85"
-components = [ "rustfmt" ]
+components = [ "rustfmt", "clippy" ]
 targets = [ "thumbv7em-none-eabi" ]


### PR DESCRIPTION
My test run of the workflow (in my fork) fails sometimes without this change.