### PR TITLE
Replace rustls-webpki with RustCrypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,10 @@ embedded-io = "0.6"
 embedded-io-async = "0.6"
 embedded-io-adapters = { version = "0.6", optional = true }
 generic-array = { version = "0.14", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.101.7", default-features = false, optional = true }
 signature = { version = "2.2", default-features = false }
 ecdsa = { version = "0.16.9", default-features = false }
+const-oid = "0.10.1"
+der = { version = "0.8.0-rc.2", features = ["derive", "oid", "time"] }
 
 # Logging alternatives
 log = { version = "0.4", optional = true }
@@ -59,3 +60,4 @@ defmt = ["dep:defmt", "embedded-io/defmt-03", "heapless/defmt-03"]
 std = ["embedded-io/std", "embedded-io-async/std"]
 tokio = ["embedded-io-adapters/tokio-1"]
 alloc = []
+webpki = []

--- a/src/decoded_certificate.rs
+++ b/src/decoded_certificate.rs
@@ -1,0 +1,98 @@
+// Based on https://github.com/FactbirdHQ/at-cryptoauth-rs/blob/master/src/cert/certificate.rs
+
+use core::cmp::Ordering;
+use der::asn1::{
+    BitStringRef, GeneralizedTime, IntRef, ObjectIdentifier, SequenceOf, SetOf,
+    UtcTime,
+};
+use der::{AnyRef, Choice, Enumerated, Sequence, ValueOrd};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Sequence, ValueOrd)]
+pub struct AlgorithmIdentifier<'a> {
+    pub oid: ObjectIdentifier,
+    pub parameters: Option<AnyRef<'a>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Enumerated)]
+#[asn1(type = "INTEGER")]
+#[repr(u8)]
+pub enum Version {
+    /// Version 1 (default)
+    V1 = 0,
+
+    /// Version 2
+    V2 = 1,
+
+    /// Version 3
+    V3 = 2,
+}
+
+impl ValueOrd for Version {
+    fn value_cmp(&self, other: &Self) -> der::Result<Ordering> {
+        (*self as u8).value_cmp(&(*other as u8))
+    }
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        Self::V1
+    }
+}
+
+#[derive(Sequence, ValueOrd)]
+pub struct DecodedCertificate<'a> {
+    pub tbs_certificate: TbsCertificate<'a>,
+    pub signature_algorithm: AlgorithmIdentifier<'a>,
+    pub signature: BitStringRef<'a>,
+}
+
+#[derive(Debug, Sequence, ValueOrd)]
+pub struct AttributeTypeAndValue<'a> {
+    pub oid: ObjectIdentifier,
+    pub value: AnyRef<'a>,
+}
+
+#[derive(Debug, Choice, ValueOrd)]
+pub enum Time {
+    #[asn1(type = "UTCTime")]
+    UtcTime(UtcTime),
+
+    #[asn1(type = "GeneralizedTime")]
+    GeneralTime(GeneralizedTime),
+}
+
+#[derive(Debug, Sequence, ValueOrd)]
+pub struct Validity {
+    pub not_before: Time,
+    pub not_after: Time,
+}
+
+#[derive(Debug, Sequence, ValueOrd)]
+pub struct SubjectPublicKeyInfoRef<'a> {
+    pub algorithm: AlgorithmIdentifier<'a>,
+    pub public_key: BitStringRef<'a>,
+}
+
+
+#[derive(Debug, Sequence, ValueOrd)]
+pub struct TbsCertificate<'a> {
+    #[asn1(context_specific = "0", default = "Default::default")]
+    pub version: Version,
+
+    pub serial_number: IntRef<'a>,
+    pub signature: AlgorithmIdentifier<'a>,
+    pub issuer: SequenceOf<SetOf<AttributeTypeAndValue<'a>, 1>, 5>,
+
+    pub validity: Validity,
+    pub subject: SequenceOf<SetOf<AttributeTypeAndValue<'a>, 1>, 5>,
+    pub subject_public_key_info: SubjectPublicKeyInfoRef<'a>,
+
+    #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
+    pub issuer_unique_id: Option<BitStringRef<'a>>,
+
+    #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
+    pub subject_unique_id: Option<BitStringRef<'a>>,
+
+    #[asn1(context_specific = "3", tag_mode = "EXPLICIT", optional = "true")]
+    pub extensions: Option<AnyRef<'a>>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,8 @@ pub use rand_core::{CryptoRng, CryptoRngCore};
 
 #[cfg(feature = "webpki")]
 pub mod webpki;
+#[cfg(feature = "webpki")]
+mod decoded_certificate;
 
 mod asynch;
 pub use asynch::*;


### PR DESCRIPTION
Trying to fix #13 (while learning Rust at the same time)

I'm pushing this draft for now in case I’m unable to finish it later. Others may use it as a starting point for their own implementations.

**Things that need more work**
- Support for intermediate CAs (public servers send at least two certificates to the client).
- Validate certificate time against the current time, and subject name against the server name.
  - A full-blown `der_derive`-based decoding might require too much memory per certificate. A solution that allows you to choose how much decoding is necessary for a particular use case might be beneficial.