### PR TITLE
Upgrade all dependencies, eliminate duplicate `heapless`, eliminate `unsafe` from examples.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,52 +10,51 @@ repository = "https://github.com/drogue-iot/embedded-tls"
 license = "Apache-2.0"
 keywords = ["embedded", "async", "tls", "no_std", "network"]
 exclude = [".github"]
+rust-version = "1.86"
 
 [dependencies]
 portable-atomic = { version = "1.6.0", default-features = false }
-p256 = { version = "0.13.2", default-features = false, features = [
+p256 = { version = "0.14.0-pre.11", default-features = false, features = [
     "ecdh",
     "ecdsa",
+    "pkcs8",
     "sha256",
 ] }
-rand_core = { version = "0.6.3", default-features = false }
-hkdf = "0.12.3"
-hmac = "0.12.1"
-sha2 = { version = "0.10.2", default-features = false }
-aes-gcm = { version = "0.10.1", default-features = false, features = ["aes"] }
-digest = { version = "0.10.3", default-features = false, features = [
-    "core-api",
-] }
-typenum = { version = "1.15.0", default-features = false }
-heapless = { version = "0.8", default-features = false }
-heapless_typenum = { package = "heapless", version = "0.6", default-features = false }
-embedded-io = "0.6"
-embedded-io-async = "0.6"
-embedded-io-adapters = { version = "0.6", optional = true }
-generic-array = { version = "0.14", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.101.7", default-features = false, optional = true }
-signature = { version = "2.2", default-features = false }
-ecdsa = { version = "0.16.9", default-features = false }
+rand_core = { version = "0.9.3", default-features = false }
+hkdf = "0.13.0-rc.1"
+hmac = "0.13.0-rc.2"
+sha2 = { version = "0.11.0-rc.2", default-features = false }
+aes-gcm = { version = "0.11.0-rc.1", default-features = false, features = ["aes"] }
+digest = "0.11.0-rc.2"
+heapless = { version = "0.9.1", default-features = false }
+embedded-io = { git = "https://github.com/rust-embedded/embedded-hal", rev = "ba020960dbe4dca076de999fa087edde021ef5df" }
+embedded-io-async = { git = "https://github.com/rust-embedded/embedded-hal", rev = "ba020960dbe4dca076de999fa087edde021ef5df" }
+embedded-io-adapters = { git = "https://github.com/rust-embedded/embedded-hal", rev = "ba020960dbe4dca076de999fa087edde021ef5df", optional = true }
+webpki = { package = "rustls-webpki", version = "0.103.6", default-features = false, optional = true }
+signature = { version = "3.0.0-rc.4", default-features = false }
+ecdsa = { version = "0.17.0-rc.7", default-features = false }
+thiserror = "2"
+pkcs8 = { version = "0.11.0-rc.7", default-features = false }
 
 # Logging alternatives
 log = { version = "0.4", optional = true }
-defmt = { version = "0.3", optional = true }
+defmt = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"
 tokio = { version = "1", features = ["full"] }
-mio = { version = "0.8.3", features = ["os-poll", "net"] }
-rustls = "0.21.6"
-rustls-pemfile = "1.0"
+mio = { version = "1.0.4", features = ["os-poll", "net"] }
+rustls = { git = "https://github.com/rustls/rustls", rev = "96e7fdcb5ab65c8da13d0ea73ccfa85fc08ac712", default-features = false, features = ["ring", "std"] }
+rustls-pemfile = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
-rand = "0.8"
+rand = "0.9"
 log = "0.4"
 pem-parser = "0.1.1"
 openssl = "0.10.44"
 
 [features]
 default = ["std", "log", "tokio"]
-defmt = ["dep:defmt", "embedded-io/defmt-03", "heapless/defmt-03"]
+defmt = ["dep:defmt", "embedded-io/defmt", "heapless/defmt"]
 std = ["embedded-io/std", "embedded-io-async/std"]
 tokio = ["embedded-io-adapters/tokio-1"]
 alloc = []

--- a/examples/blocking/src/main.rs
+++ b/examples/blocking/src/main.rs
@@ -1,13 +1,12 @@
+use std::net::TcpStream;
+use std::time::SystemTime;
+
 use embedded_io::Write as _;
 use embedded_io_adapters::std::FromStd;
 use embedded_tls::blocking::*;
 use embedded_tls::webpki::CertVerifier;
-use rand::rngs::OsRng;
-use std::net::TcpStream;
-use std::time::SystemTime;
 
 struct Provider {
-    rng: OsRng,
     verifier: CertVerifier<Aes128GcmSha256, SystemTime, 4096>,
 }
 
@@ -16,8 +15,8 @@ impl CryptoProvider for Provider {
 
     type Signature = &'static [u8];
 
-    fn rng(&mut self) -> impl embedded_tls::CryptoRngCore {
-        &mut self.rng
+    fn rng(&mut self) -> impl embedded_tls::CryptoRng {
+        rand::rng()
     }
 
     fn verifier(
@@ -44,7 +43,6 @@ fn main() {
     tls.open(TlsContext::new(
         &config,
         Provider {
-            rng: OsRng,
             verifier: CertVerifier::new(),
         },
     ))

--- a/examples/embassy/src/main.rs
+++ b/examples/embassy/src/main.rs
@@ -8,7 +8,7 @@ use embedded_io_async::Write;
 use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
 use heapless::Vec;
 use log::*;
-use rand::{rngs::OsRng, RngCore};
+use rand::RngCore;
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -47,7 +47,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    rand::rng().fill_bytes(&mut seed);
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
@@ -86,7 +86,7 @@ async fn main_task(spawner: Spawner) {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");

--- a/examples/tokio-psk/src/main.rs
+++ b/examples/tokio-psk/src/main.rs
@@ -1,10 +1,10 @@
 #![macro_use]
 
+use std::error::Error;
+
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_io_async::Write as _;
 use embedded_tls::*;
-use rand::rngs::OsRng;
-use std::error::Error;
 use tokio::net::TcpStream;
 
 #[tokio::main]
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");

--- a/examples/tokio/src/main.rs
+++ b/examples/tokio/src/main.rs
@@ -1,10 +1,10 @@
 #![macro_use]
 
+use std::error::Error;
+
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_io_async::Write as _;
 use embedded_tls::*;
-use rand::rngs::OsRng;
-use std::error::Error;
 use tokio::net::TcpStream;
 
 #[tokio::main]
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "1.85"
+channel = "1.86"
 components = [ "rustfmt", "clippy" ]
 targets = [ "thumbv7em-none-eabi" ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,25 +1,24 @@
 use core::marker::PhantomData;
 
+use aes_gcm::{AeadInOut, Aes128Gcm, Aes256Gcm, KeyInit};
+use digest::array::ArraySize;
+use digest::core_api::BlockSizeUser;
+use digest::typenum::{Sum, U10, U12, U16, U32};
+use digest::{Digest, FixedOutput, OutputSizeUser, Reset};
+use ecdsa::elliptic_curve::SecretKey;
+use heapless::Vec;
+use p256::ecdsa::SigningKey;
+use rand_core::CryptoRng;
+pub use sha2::Sha256;
+pub use sha2::Sha384;
+
 use crate::TlsError;
 use crate::cipher_suites::CipherSuite;
+pub use crate::extensions::extension_data::max_fragment_length::MaxFragmentLength;
 use crate::extensions::extension_data::signature_algorithms::SignatureScheme;
 use crate::extensions::extension_data::supported_groups::NamedGroup;
 use crate::handshake::certificate::CertificateRef;
 pub use crate::handshake::certificate_verify::CertificateVerifyRef;
-use aes_gcm::{AeadInPlace, Aes128Gcm, Aes256Gcm, KeyInit};
-use digest::core_api::BlockSizeUser;
-use digest::{Digest, FixedOutput, OutputSizeUser, Reset};
-use ecdsa::elliptic_curve::SecretKey;
-use generic_array::ArrayLength;
-use heapless::Vec;
-use p256::ecdsa::SigningKey;
-use rand_core::CryptoRngCore;
-pub use sha2::Sha256;
-
-pub use sha2::Sha384;
-use typenum::{Sum, U10, U12, U16, U32};
-
-pub use crate::extensions::extension_data::max_fragment_length::MaxFragmentLength;
 
 pub const TLS_RECORD_OVERHEAD: usize = 128;
 
@@ -34,12 +33,12 @@ type LabelBuffer<CipherSuite> = Sum<
 /// Represents a TLS 1.3 cipher suite
 pub trait TlsCipherSuite {
     const CODE_POINT: u16;
-    type Cipher: KeyInit<KeySize = Self::KeyLen> + AeadInPlace<NonceSize = Self::IvLen>;
-    type KeyLen: ArrayLength<u8>;
-    type IvLen: ArrayLength<u8>;
+    type Cipher: KeyInit<KeySize = Self::KeyLen> + AeadInOut<NonceSize = Self::IvLen>;
+    type KeyLen: ArraySize;
+    type IvLen: ArraySize;
 
     type Hash: Digest + Reset + Clone + OutputSizeUser + BlockSizeUser + FixedOutput;
-    type LabelBufferSize: ArrayLength<u8>;
+    type LabelBufferSize: ArraySize;
 }
 
 pub struct Aes128GcmSha256;
@@ -148,7 +147,7 @@ pub trait CryptoProvider {
     type CipherSuite: TlsCipherSuite;
     type Signature: AsRef<[u8]>;
 
-    fn rng(&mut self) -> impl CryptoRngCore;
+    fn rng(&mut self) -> impl CryptoRng;
 
     fn verifier(&mut self) -> Result<&mut impl TlsVerifier<Self::CipherSuite>, crate::TlsError> {
         Err::<&mut NoVerify, _>(crate::TlsError::Unimplemented)
@@ -158,8 +157,7 @@ pub trait CryptoProvider {
     fn signer(
         &mut self,
         _key_der: &[u8],
-    ) -> Result<(impl signature::SignerMut<Self::Signature>, SignatureScheme), crate::TlsError>
-    {
+    ) -> Result<(impl signature::Signer<Self::Signature>, SignatureScheme), crate::TlsError> {
         Err::<(NoSign, _), crate::TlsError>(crate::TlsError::Unimplemented)
     }
 }
@@ -169,7 +167,7 @@ impl<T: CryptoProvider> CryptoProvider for &mut T {
 
     type Signature = T::Signature;
 
-    fn rng(&mut self) -> impl CryptoRngCore {
+    fn rng(&mut self) -> impl CryptoRng {
         T::rng(self)
     }
 
@@ -180,8 +178,7 @@ impl<T: CryptoProvider> CryptoProvider for &mut T {
     fn signer(
         &mut self,
         key_der: &[u8],
-    ) -> Result<(impl signature::SignerMut<Self::Signature>, SignatureScheme), crate::TlsError>
-    {
+    ) -> Result<(impl signature::Signer<Self::Signature>, SignatureScheme), crate::TlsError> {
         T::signer(self, key_der)
     }
 }
@@ -199,7 +196,7 @@ pub struct UnsecureProvider<CipherSuite, RNG> {
     _marker: PhantomData<CipherSuite>,
 }
 
-impl<RNG: CryptoRngCore> UnsecureProvider<(), RNG> {
+impl<RNG: CryptoRng> UnsecureProvider<(), RNG> {
     pub fn new<CipherSuite: TlsCipherSuite>(rng: RNG) -> UnsecureProvider<CipherSuite, RNG> {
         UnsecureProvider {
             rng,
@@ -208,21 +205,20 @@ impl<RNG: CryptoRngCore> UnsecureProvider<(), RNG> {
     }
 }
 
-impl<CipherSuite: TlsCipherSuite, RNG: CryptoRngCore> CryptoProvider
+impl<CipherSuite: TlsCipherSuite, RNG: CryptoRng> CryptoProvider
     for UnsecureProvider<CipherSuite, RNG>
 {
     type CipherSuite = CipherSuite;
     type Signature = p256::ecdsa::DerSignature;
 
-    fn rng(&mut self) -> impl CryptoRngCore {
+    fn rng(&mut self) -> impl CryptoRng {
         &mut self.rng
     }
 
     fn signer(
         &mut self,
         key_der: &[u8],
-    ) -> Result<(impl signature::SignerMut<Self::Signature>, SignatureScheme), crate::TlsError>
-    {
+    ) -> Result<(impl signature::Signer<Self::Signature>, SignatureScheme), crate::TlsError> {
         let secret_key =
             SecretKey::from_sec1_der(key_der).map_err(|_| TlsError::InvalidPrivateKey)?;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,6 +1,21 @@
+use core::fmt::Debug;
+
+use aes_gcm::aead::{AeadCore, AeadInOut, KeyInit};
+use digest::Digest;
+use digest::typenum::Unsigned;
+use embedded_io::Error as _;
+use embedded_io::{Read as BlockingRead, Write as BlockingWrite};
+use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
+use p256::ecdh::EphemeralSecret;
+use signature::Signer;
+
+use crate::application_data::ApplicationData;
+use crate::buffer::CryptoBuffer;
 use crate::config::{TlsCipherSuite, TlsConfig};
+use crate::content_types::ContentType;
 use crate::handshake::{ClientHandshake, ServerHandshake};
 use crate::key_schedule::{KeySchedule, ReadKeySchedule, WriteKeySchedule};
+use crate::parse_buffer::ParseBuffer;
 use crate::record::{ClientRecord, ServerRecord};
 use crate::record_reader::RecordReader;
 use crate::write_buffer::WriteBuffer;
@@ -9,21 +24,6 @@ use crate::{
     alert::{Alert, AlertDescription, AlertLevel},
     handshake::{certificate::CertificateRef, certificate_request::CertificateRequest},
 };
-use core::fmt::Debug;
-use digest::Digest;
-use embedded_io::Error as _;
-use embedded_io::{Read as BlockingRead, Write as BlockingWrite};
-use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
-
-use crate::application_data::ApplicationData;
-use crate::buffer::CryptoBuffer;
-use digest::generic_array::typenum::Unsigned;
-use p256::ecdh::EphemeralSecret;
-use signature::SignerMut;
-
-use crate::content_types::ContentType;
-use crate::parse_buffer::ParseBuffer;
-use aes_gcm::aead::{AeadCore, AeadInPlace, KeyInit};
 
 pub(crate) fn decrypt_record<CipherSuite>(
     key_schedule: &mut ReadKeySchedule<CipherSuite>,
@@ -548,14 +548,14 @@ where
     Provider: CryptoProvider,
 {
     let (result, record) = match crypto_provider.signer(config.priv_key) {
-        Ok((mut signing_key, signature_scheme)) => {
+        Ok((signing_key, signature_scheme)) => {
             let ctx_str = b"TLS 1.3, client CertificateVerify\x00";
             let mut msg: heapless::Vec<u8, 130> = heapless::Vec::new();
-            msg.resize(64, 0x20).map_err(|()| TlsError::EncodeError)?;
+            msg.resize(64, 0x20).map_err(|_| TlsError::EncodeError)?;
             msg.extend_from_slice(ctx_str)
-                .map_err(|()| TlsError::EncodeError)?;
+                .map_err(|_| TlsError::EncodeError)?;
             msg.extend_from_slice(&key_schedule.transcript_hash().clone().finalize())
-                .map_err(|()| TlsError::EncodeError)?;
+                .map_err(|_| TlsError::EncodeError)?;
 
             let signature = signing_key.sign(&msg);
 

--- a/src/handshake/binder.rs
+++ b/src/handshake/binder.rs
@@ -1,28 +1,28 @@
+use core::fmt::{Debug, Formatter};
+
+use digest::array::{Array, ArraySize};
+
 use crate::TlsError;
 use crate::buffer::CryptoBuffer;
-use core::fmt::{Debug, Formatter};
-//use digest::generic_array::{ArrayLength, GenericArray};
-use generic_array::{ArrayLength, GenericArray};
-// use heapless::Vec;
 
-pub struct PskBinder<N: ArrayLength<u8>> {
-    pub verify: GenericArray<u8, N>,
+pub struct PskBinder<N: ArraySize> {
+    pub verify: Array<u8, N>,
 }
 
 #[cfg(feature = "defmt")]
-impl<N: ArrayLength<u8>> defmt::Format for PskBinder<N> {
+impl<N: ArraySize> defmt::Format for PskBinder<N> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f, "verify length:{}", &self.verify.len());
     }
 }
 
-impl<N: ArrayLength<u8>> Debug for PskBinder<N> {
+impl<N: ArraySize> Debug for PskBinder<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("PskBinder").finish()
     }
 }
 
-impl<N: ArrayLength<u8>> PskBinder<N> {
+impl<N: ArraySize> PskBinder<N> {
     pub(crate) fn encode(&self, buf: &mut CryptoBuffer<'_>) -> Result<(), TlsError> {
         let len = self.verify.len() as u8;
         //buf.extend_from_slice(&[len[1], len[2], len[3]]);

--- a/src/handshake/certificate.rs
+++ b/src/handshake/certificate.rs
@@ -1,8 +1,9 @@
+use heapless::Vec;
+
 use crate::TlsError;
 use crate::buffer::CryptoBuffer;
 use crate::extensions::messages::CertificateExtension;
 use crate::parse_buffer::ParseBuffer;
-use heapless::Vec;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -146,11 +147,11 @@ impl<'a, const N: usize> TryFrom<CertificateRef<'a>> for Certificate<N> {
         let mut request_context = Vec::new();
         request_context
             .extend_from_slice(cert.request_context)
-            .map_err(|()| TlsError::OutOfMemory)?;
+            .map_err(|_| TlsError::OutOfMemory)?;
         let mut entries_data = Vec::new();
         entries_data
             .extend_from_slice(cert.raw_entries)
-            .map_err(|()| TlsError::OutOfMemory)?;
+            .map_err(|_| TlsError::OutOfMemory)?;
 
         Ok(Self {
             request_context,

--- a/src/handshake/certificate_request.rs
+++ b/src/handshake/certificate_request.rs
@@ -1,7 +1,8 @@
+use heapless::Vec;
+
 use crate::extensions::messages::CertificateRequestExtension;
 use crate::parse_buffer::ParseBuffer;
 use crate::{TlsError, unused};
-use heapless::Vec;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -40,7 +41,7 @@ impl<'a> TryFrom<CertificateRequestRef<'a>> for CertificateRequest {
         let mut request_context = Vec::new();
         request_context
             .extend_from_slice(cert.request_context)
-            .map_err(|()| {
+            .map_err(|_| {
                 error!("CertificateRequest: InsufficientSpace");
                 TlsError::InsufficientSpace
             })?;

--- a/src/handshake/client_hello.rs
+++ b/src/handshake/client_hello.rs
@@ -1,11 +1,11 @@
 use core::marker::PhantomData;
 
+use digest::typenum::Unsigned;
 use digest::{Digest, OutputSizeUser};
 use heapless::Vec;
 use p256::EncodedPoint;
 use p256::ecdh::EphemeralSecret;
 use p256::elliptic_curve::rand_core::RngCore;
-use typenum::Unsigned;
 
 use crate::TlsError;
 use crate::config::{TlsCipherSuite, TlsConfig};

--- a/src/handshake/finished.rs
+++ b/src/handshake/finished.rs
@@ -1,24 +1,24 @@
+use core::fmt::{Debug, Formatter};
+
+use digest::array::{Array, ArraySize};
+
 use crate::TlsError;
 use crate::buffer::CryptoBuffer;
 use crate::parse_buffer::ParseBuffer;
-use core::fmt::{Debug, Formatter};
-//use digest::generic_array::{ArrayLength, GenericArray};
-use generic_array::{ArrayLength, GenericArray};
-// use heapless::Vec;
 
-pub struct Finished<N: ArrayLength<u8>> {
-    pub verify: GenericArray<u8, N>,
-    pub hash: Option<GenericArray<u8, N>>,
+pub struct Finished<N: ArraySize> {
+    pub verify: Array<u8, N>,
+    pub hash: Option<Array<u8, N>>,
 }
 
 #[cfg(feature = "defmt")]
-impl<N: ArrayLength<u8>> defmt::Format for Finished<N> {
+impl<N: ArraySize> defmt::Format for Finished<N> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f, "verify length:{}", &self.verify.len());
     }
 }
 
-impl<N: ArrayLength<u8>> Debug for Finished<N> {
+impl<N: ArraySize> Debug for Finished<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Finished")
             .field("verify", &self.hash)
@@ -26,12 +26,12 @@ impl<N: ArrayLength<u8>> Debug for Finished<N> {
     }
 }
 
-impl<N: ArrayLength<u8>> Finished<N> {
+impl<N: ArraySize> Finished<N> {
     pub fn parse(buf: &mut ParseBuffer, _len: u32) -> Result<Self, TlsError> {
         // info!("finished len: {}", len);
-        let mut verify = GenericArray::default();
+        let mut verify = Array::default();
         buf.fill(&mut verify)?;
-        //let hash = GenericArray::from_slice()
+        //let hash = Array::from_slice()
         //let hash: Result<Vec<u8, _>, ()> = buf
         //.slice(len as usize)
         //.map_err(|_| TlsError::InvalidHandshake)?

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -1,19 +1,20 @@
+use digest::OutputSizeUser;
+use digest::array::{Array, ArraySize};
+use digest::typenum::Unsigned;
+use hmac::{KeyInit, Mac, SimpleHmac};
+use sha2::Digest;
+
 use crate::handshake::binder::PskBinder;
 use crate::handshake::finished::Finished;
 use crate::{TlsError, config::TlsCipherSuite};
-use digest::OutputSizeUser;
-use digest::generic_array::ArrayLength;
-use hmac::{Mac, SimpleHmac};
-use sha2::Digest;
-use sha2::digest::generic_array::{GenericArray, typenum::Unsigned};
 
 pub type HashOutputSize<CipherSuite> =
     <<CipherSuite as TlsCipherSuite>::Hash as OutputSizeUser>::OutputSize;
 pub type LabelBufferSize<CipherSuite> = <CipherSuite as TlsCipherSuite>::LabelBufferSize;
 
-pub type IvArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::IvLen>;
-pub type KeyArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::KeyLen>;
-pub type HashArray<CipherSuite> = GenericArray<u8, HashOutputSize<CipherSuite>>;
+pub type IvArray<CipherSuite> = Array<u8, <CipherSuite as TlsCipherSuite>::IvLen>;
+pub type KeyArray<CipherSuite> = Array<u8, <CipherSuite as TlsCipherSuite>::KeyLen>;
+pub type HashArray<CipherSuite> = Array<u8, HashOutputSize<CipherSuite>>;
 
 type Hkdf<CipherSuite> = hkdf::Hkdf<
     <CipherSuite as TlsCipherSuite>::Hash,
@@ -43,46 +44,43 @@ where
         }
     }
 
-    fn make_expanded_hkdf_label<N: ArrayLength<u8>>(
+    fn make_expanded_hkdf_label<N: ArraySize>(
         &self,
         label: &[u8],
         context_type: ContextType<CipherSuite>,
-    ) -> Result<GenericArray<u8, N>, TlsError> {
+    ) -> Result<Array<u8, N>, TlsError> {
+        fn copy_slice(dest: &mut [u8], src: &[u8]) -> usize {
+            let len = src.len();
+            dest[..len].copy_from_slice(src);
+            len
+        }
+
         //info!("make label {:?} {}", label, len);
-        let mut hkdf_label = heapless_typenum::Vec::<u8, LabelBufferSize<CipherSuite>>::new();
-        hkdf_label
-            .extend_from_slice(&N::to_u16().to_be_bytes())
-            .map_err(|()| TlsError::InternalError)?;
+
+        let mut hkdf_label = Array::<u8, LabelBufferSize<CipherSuite>>::from_fn(|_| 0);
+        let mut i = 0;
+
+        i += copy_slice(&mut hkdf_label[i..], &N::to_u16().to_be_bytes());
 
         let label_len = 6 + label.len() as u8;
-        hkdf_label
-            .extend_from_slice(&label_len.to_be_bytes())
-            .map_err(|()| TlsError::InternalError)?;
-        hkdf_label
-            .extend_from_slice(b"tls13 ")
-            .map_err(|()| TlsError::InternalError)?;
-        hkdf_label
-            .extend_from_slice(label)
-            .map_err(|()| TlsError::InternalError)?;
+        i += copy_slice(&mut hkdf_label[i..], &label_len.to_be_bytes());
+        i += copy_slice(&mut hkdf_label[i..], b"tls13 ");
+        i += copy_slice(&mut hkdf_label[i..], label);
 
         match context_type {
             ContextType::None => {
-                hkdf_label.push(0).map_err(|_| TlsError::InternalError)?;
+                i += copy_slice(&mut hkdf_label[i..], &[0]);
             }
             ContextType::Hash(context) => {
-                hkdf_label
-                    .extend_from_slice(&(context.len() as u8).to_be_bytes())
-                    .map_err(|()| TlsError::InternalError)?;
-                hkdf_label
-                    .extend_from_slice(&context)
-                    .map_err(|()| TlsError::InternalError)?;
+                i += copy_slice(&mut hkdf_label[i..], &[context.len() as u8]);
+                i += copy_slice(&mut hkdf_label[i..], &context);
             }
         }
 
-        let mut okm = GenericArray::default();
+        let mut okm = Array::default();
         //info!("label {:x?}", label);
         self.as_ref()?
-            .expand(&hkdf_label, &mut okm)
+            .expand(&hkdf_label[..i], &mut okm)
             .map_err(|_| TlsError::CryptoError)?;
         //info!("expand {:x?}", okm);
         Ok(okm)
@@ -103,7 +101,7 @@ where
 {
     fn new() -> Self {
         Self {
-            secret: GenericArray::default(),
+            secret: Array::default(),
             hkdf: Secret::Uninitialized,
         }
     }
@@ -290,7 +288,7 @@ where
         //info!("counter = {:x?}", counter);
         // info!("iv = {:x?}", iv);
 
-        let mut nonce = GenericArray::default();
+        let mut nonce = Array::default();
 
         for (index, (l, r)) in iv[0..CipherSuite::IvLen::to_usize()]
             .iter()
@@ -305,9 +303,9 @@ where
         nonce
     }
 
-    fn pad<N: ArrayLength<u8>>(input: &[u8]) -> GenericArray<u8, N> {
+    fn pad<N: ArraySize>(input: &[u8]) -> Array<u8, N> {
         // info!("padding input = {:x?}", input);
-        let mut padded = GenericArray::default();
+        let mut padded = Array::default();
         for (index, byte) in input.iter().rev().enumerate() {
             /*info!(
                 "{} pad {}={:x?}",
@@ -321,7 +319,7 @@ where
     }
 
     fn zero() -> HashArray<CipherSuite> {
-        GenericArray::default()
+        Array::default()
     }
 
     // Initializes the early secrets with a callback for any PSK binders

--- a/src/parse_buffer.rs
+++ b/src/parse_buffer.rs
@@ -1,5 +1,6 @@
+use heapless::{CapacityError, Vec};
+
 use crate::TlsError;
-use heapless::Vec;
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -20,7 +21,7 @@ impl<'b> From<&'b [u8]> for ParseBuffer<'b> {
     }
 }
 
-impl<'b, const N: usize> From<ParseBuffer<'b>> for Result<Vec<u8, N>, ()> {
+impl<'b, const N: usize> From<ParseBuffer<'b>> for Result<Vec<u8, N>, CapacityError> {
     fn from(val: ParseBuffer<'b>) -> Self {
         Vec::from_slice(&val.buffer[val.pos..])
     }
@@ -133,7 +134,7 @@ impl<'b> ParseBuffer<'b> {
             Err(ParseError::InsufficientSpace)
         } else if self.pos + num_bytes <= self.buffer.len() {
             dest.extend_from_slice(&self.buffer[self.pos..self.pos + num_bytes])
-                .map_err(|()| {
+                .map_err(|_| {
                     error!(
                         "Failed to extend destination buffer. Space: {} required: {}",
                         space, num_bytes

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,3 +1,5 @@
+use core::fmt::Debug;
+
 use crate::TlsError;
 use crate::application_data::ApplicationData;
 use crate::change_cipher_spec::ChangeCipherSpec;
@@ -11,14 +13,12 @@ use crate::{
     alert::{Alert, AlertDescription, AlertLevel},
     parse_buffer::ParseBuffer,
 };
-use core::fmt::Debug;
 
 pub type Encrypted = bool;
 
 #[allow(clippy::large_enum_variant)]
 pub enum ClientRecord<'config, 'a, CipherSuite>
 where
-    // N: ArrayLength<u8>,
     CipherSuite: TlsCipherSuite,
 {
     Handshake(ClientHandshake<'config, 'a, CipherSuite>, Encrypted),
@@ -80,7 +80,6 @@ impl ClientRecordHeader {
 
 impl<'config, CipherSuite> ClientRecord<'config, '_, CipherSuite>
 where
-    //N: ArrayLength<u8>,
     CipherSuite: TlsCipherSuite,
 {
     pub fn header(&self) -> ClientRecordHeader {

--- a/tests/client_cert_test.rs
+++ b/tests/client_cert_test.rs
@@ -1,29 +1,30 @@
+use std::net::SocketAddr;
+use std::sync::{Arc, OnceLock};
+
 use ecdsa::elliptic_curve::SecretKey;
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_tls::{CryptoProvider, SignatureScheme};
 use p256::ecdsa::SigningKey;
-use rand::rngs::OsRng;
-use rand_core::CryptoRngCore;
-use rustls::server::AllowAnyAuthenticatedClient;
-use std::net::SocketAddr;
-use std::sync::Once;
+use rand_core::CryptoRng;
+use rustls::server::WebPkiClientVerifier;
 
 mod tlsserver;
 
-static LOG_INIT: Once = Once::new();
-static INIT: Once = Once::new();
-static mut ADDR: Option<SocketAddr> = None;
-
-fn init_log() {
-    LOG_INIT.call_once(|| {
-        env_logger::init();
-    });
-}
+static ADDR: OnceLock<SocketAddr> = OnceLock::new();
 
 fn setup() -> SocketAddr {
     use mio::net::TcpListener;
-    init_log();
-    INIT.call_once(|| {
+
+    *ADDR.get_or_init(|| {
+        env_logger::init();
+
+        let mut crypto_provider = rustls::crypto::ring::default_provider();
+        crypto_provider.tls12_cipher_suites = Vec::new();
+        crypto_provider.tls13_cipher_suites =
+            rustls::crypto::ring::ALL_TLS13_CIPHER_SUITES.to_vec();
+        crypto_provider.kx_groups = rustls::crypto::ring::ALL_KX_GROUPS.to_vec();
+        crypto_provider.install_default().unwrap();
+
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
 
         let listener = TcpListener::bind(addr).expect("cannot listen on port");
@@ -34,8 +35,6 @@ fn setup() -> SocketAddr {
         std::thread::spawn(move || {
             use tlsserver::*;
 
-            let versions = &[&rustls::version::TLS13];
-
             let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
             let ca = load_certs(&test_dir.join("data").join("ca-cert.pem"));
@@ -43,48 +42,41 @@ fn setup() -> SocketAddr {
             let privkey = load_private_key(&test_dir.join("data").join("server-key.pem"));
 
             let mut client_auth_roots = rustls::RootCertStore::empty();
-            for root in ca.iter() {
+            for root in ca.into_iter() {
                 client_auth_roots.add(root).unwrap()
             }
 
-            let client_cert_verifier = AllowAnyAuthenticatedClient::new(client_auth_roots);
+            let client_cert_verifier = WebPkiClientVerifier::builder(Arc::new(client_auth_roots))
+                .build()
+                .unwrap();
 
             let config = rustls::ServerConfig::builder()
-                .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
-                .with_kx_groups(&rustls::ALL_KX_GROUPS)
-                .with_protocol_versions(versions)
-                .unwrap()
-                .with_client_cert_verifier(client_cert_verifier.boxed())
+                .with_client_cert_verifier(client_cert_verifier)
                 .with_single_cert(certs, privkey)
                 .unwrap();
 
             run_with_config(listener, config);
         });
-        #[allow(static_mut_refs)]
-        unsafe {
-            ADDR.replace(addr)
-        };
-    });
-    unsafe { ADDR.unwrap() }
+
+        addr
+    })
 }
 
 #[derive(Default)]
-struct Provider {
-    rng: OsRng,
-}
+struct Provider;
 
 impl CryptoProvider for Provider {
     type CipherSuite = embedded_tls::Aes128GcmSha256;
     type Signature = p256::ecdsa::DerSignature;
 
-    fn rng(&mut self) -> impl CryptoRngCore {
-        &mut self.rng
+    fn rng(&mut self) -> impl CryptoRng {
+        rand::rng()
     }
 
     fn signer(
         &mut self,
         key_der: &[u8],
-    ) -> Result<(impl signature::SignerMut<Self::Signature>, SignatureScheme), embedded_tls::TlsError>
+    ) -> Result<(impl signature::Signer<Self::Signature>, SignatureScheme), embedded_tls::TlsError>
     {
         let secret_key = SecretKey::from_sec1_der(key_der)
             .map_err(|_| embedded_tls::TlsError::InvalidPrivateKey)?;

--- a/tests/psk_test.rs
+++ b/tests/psk_test.rs
@@ -1,12 +1,13 @@
 #![macro_use]
-use embedded_io_adapters::tokio_1::FromTokio;
-use embedded_tls::*;
-use openssl::ssl;
-use rand::rngs::OsRng;
+
 use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::net::TcpListener;
 use std::sync::Once;
+
+use embedded_io_adapters::tokio_1::FromTokio;
+use embedded_tls::*;
+use openssl::ssl;
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
@@ -84,7 +85,7 @@ async fn test_psk_open() {
         assert!(
             tls.open(TlsContext::new(
                 &config,
-                UnsecureProvider::new::<Aes128GcmSha256>(OsRng)
+                UnsecureProvider::new::<Aes128GcmSha256>(rand::rng())
             ))
             .await
             .is_ok()

--- a/tests/webpki_test.rs
+++ b/tests/webpki_test.rs
@@ -1,11 +1,12 @@
 #![cfg(feature = "webpki")]
 
-use embedded_io_adapters::tokio_1::FromTokio;
-use embedded_tls::webpki::CertVerifier;
-use embedded_tls::{Aes128GcmSha256, CryptoProvider, TlsVerifier};
 use std::net::SocketAddr;
 use std::sync::OnceLock;
 use std::time::SystemTime;
+
+use embedded_io_adapters::tokio_1::FromTokio;
+use embedded_tls::webpki::CertVerifier;
+use embedded_tls::{Aes128GcmSha256, CryptoProvider, TlsVerifier};
 
 mod tlsserver;
 
@@ -13,7 +14,6 @@ static LOG_INIT: OnceLock<()> = OnceLock::new();
 
 #[derive(Default)]
 struct WebPkiProvider {
-    rng: rand::rngs::OsRng,
     verifier: CertVerifier<Aes128GcmSha256, SystemTime, 4096>,
 }
 
@@ -21,8 +21,8 @@ impl CryptoProvider for WebPkiProvider {
     type CipherSuite = Aes128GcmSha256;
     type Signature = &'static [u8];
 
-    fn rng(&mut self) -> impl embedded_tls::CryptoRngCore {
-        &mut self.rng
+    fn rng(&mut self) -> impl embedded_tls::CryptoRng {
+        rand::rng()
     }
 
     fn verifier(


### PR DESCRIPTION
`embedded-io`, `rustls`, and all RustCrypto crates are under heavy development, with many breaking changes even compared to their latest released versions. Hence, I didn't stop half-way, but went for the latest bleeding-edge prerelease versions of these crates. This PR should likely be merged once all dependencies are available as final versions.

Anyway, I'd be happy if you could already have a look and give some early feedback.

CC @bugadani @lulf @newAM 