### PR TITLE
Fix client certificate verify buffer size for SHA-384

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -550,7 +550,8 @@ where
     let (result, record) = match crypto_provider.signer(config.priv_key) {
         Ok((mut signing_key, signature_scheme)) => {
             let ctx_str = b"TLS 1.3, client CertificateVerify\x00";
-            let mut msg: heapless::Vec<u8, 130> = heapless::Vec::new();
+            // 64 (pad) + 34 (ctx) + 48 (SHA-384) = 146 bytes required
+            let mut msg: heapless::Vec<u8, 146> = heapless::Vec::new();
             msg.resize(64, 0x20).map_err(|()| TlsError::EncodeError)?;
             msg.extend_from_slice(ctx_str)
                 .map_err(|()| TlsError::EncodeError)?;


### PR DESCRIPTION
Increase the heapless::Vec buffer from 130 to 146 bytes in client_cert_verify to accommodate SHA-384 transcript hashes.

Buffer calculation: 64 (pad) + 34 (ctx) + 48 (SHA-384) = 146 bytes.

The current buffer only accounted for SHA-256 (32 bytes) which is causing an EncodeError when using Aes256GcmSha384 cipher suite with client certificate authentication.