### PR TITLE
Support extra attributes in subject and issuer

### DIFF
--- a/src/der_certificate.rs
+++ b/src/der_certificate.rs
@@ -141,10 +141,10 @@ pub struct TbsCertificate<'a> {
 
     pub serial_number: IntRef<'a>,
     pub signature: AlgorithmIdentifier<'a>,
-    pub issuer: SequenceOf<SetOf<AttributeTypeAndValue<'a>, 1>, 5>,
+    pub issuer: SequenceOf<SetOf<AttributeTypeAndValue<'a>, 1>, 7>,
 
     pub validity: Validity,
-    pub subject: SequenceOf<SetOf<AttributeTypeAndValue<'a>, 1>, 5>,
+    pub subject: SequenceOf<SetOf<AttributeTypeAndValue<'a>, 1>, 7>,
     pub subject_public_key_info: SubjectPublicKeyInfoRef<'a>,
 
     #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -301,8 +301,10 @@ fn verify_certificate(
     };
 
     if let CertificateEntryRef::X509(certificate) = certificate {
-        let parsed_certificate =
-            DecodedCertificate::from_der(certificate).map_err(|_| TlsError::DecodeError)?;
+        let parsed_certificate = DecodedCertificate::from_der(certificate).map_err(|e| {
+            error!("DecodedCertificate::from_der: {}", e);
+            TlsError::DecodeError
+        })?;
 
         let ca_public_key = ca_certificate
             .tbs_certificate


### PR DESCRIPTION
Some organizations put uncommon attributes in the subject of a certificate. This patch allows space for two extra attributes.