### PR TITLE
Hotfix: crate::der has no defmt, so remove this error log

### DIFF
--- a/src/pki.rs
+++ b/src/pki.rs
@@ -301,10 +301,8 @@ fn verify_certificate(
     };
 
     if let CertificateEntryRef::X509(certificate) = certificate {
-        let parsed_certificate = DecodedCertificate::from_der(certificate).map_err(|e| {
-            error!("DecodedCertificate::from_der: {}", e);
-            TlsError::DecodeError
-        })?;
+        let parsed_certificate =
+            DecodedCertificate::from_der(certificate).map_err(|_| TlsError::DecodeError)?;
 
         let ca_public_key = ca_certificate
             .tbs_certificate


### PR DESCRIPTION
Without this hotfix, _rustpki_ won't compile with _defmt_.