### PR TITLE
Make p384 and ed25519 optional signature methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ exclude = [".github"]
 [dependencies]
 portable-atomic = { version = "1.6.0", default-features = false }
 p256 = { version = "0.13", default-features = false, features = [ "ecdh", "ecdsa", "sha256" ] }
-p384 = { version = "0.13", default-features = false, features = [ "ecdh", "ecdsa", "sha384" ] }
-ed25519-dalek = { version = "2.2", default-features = false }
+p384 = { version = "0.13", default-features = false, features = [ "ecdsa", "sha384" ], optional = true }
+ed25519-dalek = { version = "2.2", default-features = false, optional = true }
 rsa = { version = "0.9.9", default-features = false, features = ["sha2"], optional = true }
 rand_core = { version = "0.6.3", default-features = false }
 hkdf = "0.12.3"
@@ -61,3 +61,5 @@ alloc = []
 webpki = ["dep:webpki"]
 rustpki = ["dep:der","dep:const-oid"]
 rsa = ["dep:rsa", "rustpki", "alloc"]
+ed25519 = ["dep:ed25519-dalek", "rustpki"]
+p384 = ["dep:p384", "rustpki"]

--- a/src/der_certificate.rs
+++ b/src/der_certificate.rs
@@ -21,10 +21,12 @@ pub const ECDSA_SHA256: AlgorithmIdentifier = AlgorithmIdentifier {
     oid: ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2"),
     parameters: None,
 };
+#[cfg(feature = "p384")]
 pub const ECDSA_SHA384: AlgorithmIdentifier = AlgorithmIdentifier {
     oid: ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3"),
     parameters: None,
 };
+#[cfg(feature = "ed25519")]
 pub const ED25519: AlgorithmIdentifier = AlgorithmIdentifier {
     oid: ObjectIdentifier::new_unwrap("1.3.101.112"),
     parameters: None,


### PR DESCRIPTION
Some signature methods have a huge impact on code size. Make them optional, so that users can pick what they need.