### PR TITLE
Upgrade all dependencies (2026-01 edition).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ rust-version = "1.87"
 
 [dependencies]
 portable-atomic = { version = "1.13.0", default-features = false }
-p256 = { version = "=0.14.0-rc.4", default-features = false, features = ["ecdh", "ecdsa", "pkcs8", "sha256"] }
-p384 = { version = "=0.14.0-rc.4", default-features = false, features = ["ecdsa", "sha384"], optional = true }
+p256 = { version = "=0.14.0-rc.5", default-features = false, features = ["ecdh", "ecdsa", "pkcs8", "sha256"] }
+p384 = { version = "=0.14.0-rc.5", default-features = false, features = ["ecdsa", "sha384"], optional = true }
 ed25519-dalek = { version = "=3.0.0-pre.4", default-features = false, optional = true }
-rsa = { version = "=0.10.0-rc.12", default-features = false, features = ["encoding", "sha2"], optional = true }
-rand_core = { version = "=0.10.0-rc-3", default-features = false }
+rsa = { version = "=0.10.0-rc.13", default-features = false, features = ["encoding", "sha2"], optional = true }
+rand_core = { version = "=0.10.0-rc-5", default-features = false }
 hkdf = "=0.13.0-rc.3"
 hmac = "=0.13.0-rc.3"
 sha2 = { version = "=0.11.0-rc.3", default-features = false }
 aes-gcm = { version = "=0.11.0-rc.2", default-features = false, features = ["aes"] }
-digest = "=0.11.0-rc.5"
+digest = "=0.11.0-rc.7"
 heapless = { version = "0.9.2", default-features = false }
 embedded-io = "0.7.1"
 embedded-io-async = "0.7.0"
@@ -32,8 +32,8 @@ pki-types = { package = "rustls-pki-types", version = "1.14.0", default-features
 webpki = { package = "rustls-webpki", version = "0.103.9", default-features = false, features = ["ring"], optional = true }
 const-oid = { version = "0.10.2", optional = true }
 der = { version = "=0.8.0-rc.10", features = ["derive", "oid", "time"], optional = true }
-signature = { version = "=3.0.0-rc.6", default-features = false }
-ecdsa = { version = "=0.17.0-rc.12", default-features = false }
+signature = { version = "=3.0.0-rc.8", default-features = false }
+ecdsa = { version = "=0.17.0-rc.13", default-features = false }
 
 # Logging alternatives
 log = { version = "0.4", optional = true }
@@ -47,7 +47,7 @@ mio = { version = "1.1.1", features = ["os-poll", "net"] }
 rustls = { version = "0.23.36", features = ["ring", "std"], default-features = false }
 rustls-pemfile = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
-rand = "=0.10.0-rc.6"
+rand = "=0.10.0-rc.7"
 log = "0.4"
 pem-parser = "0.1.1"
 openssl = "0.10.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,31 +10,29 @@ repository = "https://github.com/drogue-iot/embedded-tls"
 license = "Apache-2.0"
 keywords = ["embedded", "async", "tls", "no_std", "network"]
 exclude = [".github"]
+rust-version = "1.87"
 
 [dependencies]
-portable-atomic = { version = "1.6.0", default-features = false }
-p256 = { version = "0.13", default-features = false, features = [ "ecdh", "ecdsa", "sha256" ] }
-p384 = { version = "0.13", default-features = false, features = [ "ecdsa", "sha384" ], optional = true }
+portable-atomic = { version = "1.13.0", default-features = false }
+p256 = { version = "0.14.0-rc.4", default-features = false, features = [ "ecdh", "ecdsa", "pkcs8", "sha256" ] }
+p384 = { version = "0.14.0-rc.4", default-features = false, features = [ "ecdsa", "sha384" ], optional = true }
 ed25519-dalek = { version = "2.2", default-features = false, optional = true }
-rsa = { version = "0.9.9", default-features = false, features = ["sha2"], optional = true }
-rand_core = { version = "0.6.3", default-features = false }
-hkdf = "0.12.3"
-hmac = "0.12.1"
-sha2 = { version = "0.10.2", default-features = false }
-aes-gcm = { version = "0.10.1", default-features = false, features = ["aes"] }
-digest = { version = "0.10.3", default-features = false, features = [ "core-api" ] }
-typenum = { version = "1.15.0", default-features = false }
-heapless = { version = "0.9", default-features = false }
-heapless_typenum = { package = "heapless", version = "0.6", default-features = false }
-embedded-io = "0.7"
-embedded-io-async = "0.7"
-embedded-io-adapters = { version = "0.7", optional = true }
-generic-array = { version = "0.14", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.101.7", default-features = false, optional = true }
-const-oid = { version = "0.10.1", optional = true }
-der = { version = "0.8.0-rc.2", features = ["derive", "oid", "time"], optional = true }
-signature = { version = "2.2", default-features = false }
-ecdsa = { version = "0.16.9", default-features = false }
+rsa = { version = "0.10.0-rc.12", default-features = false, features = ["sha2"], optional = true }
+rand_core = { version = "0.10.0-rc-3", default-features = false }
+hkdf = "0.13.0-rc.3"
+hmac = "0.13.0-rc.3"
+sha2 = { version = "0.11.0-rc.3", default-features = false }
+aes-gcm = { version = "0.11.0-rc.2", default-features = false, features = ["aes"] }
+digest = "0.11.0-rc.5"
+heapless = { version = "0.9.2", default-features = false }
+embedded-io = "0.7.1"
+embedded-io-async = "0.7.0"
+embedded-io-adapters = { version = "0.7.0", optional = true }
+webpki = { package = "rustls-webpki", version = "0.103.8", default-features = false, optional = true }
+const-oid = { version = "0.10.2", optional = true }
+der = { version = "0.8.0-rc.10", features = ["derive", "oid", "time"], optional = true }
+signature = { version = "3.0.0-rc.6", default-features = false }
+ecdsa = { version = "0.17.0-rc.12", default-features = false }
 
 # Logging alternatives
 log = { version = "0.4", optional = true }
@@ -43,14 +41,15 @@ defmt = { version = "1.0.1", optional = true }
 [dev-dependencies]
 env_logger = "0.11"
 tokio = { version = "1", features = ["full"] }
-mio = { version = "0.8.3", features = ["os-poll", "net"] }
-rustls = "0.21.6"
-rustls-pemfile = "1.0"
+mio = { version = "1.1.1", features = ["os-poll", "net"] }
+# We deliberately disable default features to not pull in TLS 1.2 support.
+rustls = { version = "0.23.36", features = ["ring", "std"], default-features = false }
+rustls-pemfile = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
-rand = "0.8"
+rand = "0.10.0-rc.6"
 log = "0.4"
 pem-parser = "0.1.1"
-openssl = "0.10.44"
+openssl = "0.10.75"
 
 [features]
 default = ["std", "log", "tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ rust-version = "1.87"
 
 [dependencies]
 portable-atomic = { version = "1.13.0", default-features = false }
-p256 = { version = "=0.14.0-rc.4", default-features = false, features = [ "ecdh", "ecdsa", "pkcs8", "sha256" ] }
-p384 = { version = "=0.14.0-rc.4", default-features = false, features = [ "ecdsa", "sha384" ], optional = true }
-ed25519-dalek = { version = "2.2", default-features = false, optional = true }
-rsa = { version = "=0.10.0-rc.12", default-features = false, features = ["sha2"], optional = true }
+p256 = { version = "=0.14.0-rc.4", default-features = false, features = ["ecdh", "ecdsa", "pkcs8", "sha256"] }
+p384 = { version = "=0.14.0-rc.4", default-features = false, features = ["ecdsa", "sha384"], optional = true }
+ed25519-dalek = { version = "=3.0.0-pre.4", default-features = false, optional = true }
+rsa = { version = "=0.10.0-rc.12", default-features = false, features = ["encoding", "sha2"], optional = true }
 rand_core = { version = "=0.10.0-rc-3", default-features = false }
 hkdf = "=0.13.0-rc.3"
 hmac = "=0.13.0-rc.3"
@@ -28,7 +28,8 @@ heapless = { version = "0.9.2", default-features = false }
 embedded-io = "0.7.1"
 embedded-io-async = "0.7.0"
 embedded-io-adapters = { version = "0.7.0", optional = true }
-webpki = { package = "rustls-webpki", version = "0.103.8", default-features = false, optional = true }
+pki-types = { package = "rustls-pki-types", version = "1.14.0", default-features = false, optional = true }
+webpki = { package = "rustls-webpki", version = "0.103.9", default-features = false, features = ["ring"], optional = true }
 const-oid = { version = "0.10.2", optional = true }
 der = { version = "=0.8.0-rc.10", features = ["derive", "oid", "time"], optional = true }
 signature = { version = "=3.0.0-rc.6", default-features = false }
@@ -57,7 +58,7 @@ defmt = ["dep:defmt", "embedded-io/defmt", "heapless/defmt"]
 std = ["embedded-io/std", "embedded-io-async/std"]
 tokio = ["embedded-io-adapters/tokio-1"]
 alloc = []
-webpki = ["dep:webpki"]
+webpki = ["dep:pki-types", "dep:webpki"]
 rustpki = ["dep:der","dep:const-oid"]
 rsa = ["dep:rsa", "rustpki", "alloc"]
 ed25519 = ["dep:ed25519-dalek", "rustpki"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,25 +14,25 @@ rust-version = "1.87"
 
 [dependencies]
 portable-atomic = { version = "1.13.0", default-features = false }
-p256 = { version = "0.14.0-rc.4", default-features = false, features = [ "ecdh", "ecdsa", "pkcs8", "sha256" ] }
-p384 = { version = "0.14.0-rc.4", default-features = false, features = [ "ecdsa", "sha384" ], optional = true }
+p256 = { version = "=0.14.0-rc.4", default-features = false, features = [ "ecdh", "ecdsa", "pkcs8", "sha256" ] }
+p384 = { version = "=0.14.0-rc.4", default-features = false, features = [ "ecdsa", "sha384" ], optional = true }
 ed25519-dalek = { version = "2.2", default-features = false, optional = true }
-rsa = { version = "0.10.0-rc.12", default-features = false, features = ["sha2"], optional = true }
-rand_core = { version = "0.10.0-rc-3", default-features = false }
-hkdf = "0.13.0-rc.3"
-hmac = "0.13.0-rc.3"
-sha2 = { version = "0.11.0-rc.3", default-features = false }
-aes-gcm = { version = "0.11.0-rc.2", default-features = false, features = ["aes"] }
-digest = "0.11.0-rc.5"
+rsa = { version = "=0.10.0-rc.12", default-features = false, features = ["sha2"], optional = true }
+rand_core = { version = "=0.10.0-rc-3", default-features = false }
+hkdf = "=0.13.0-rc.3"
+hmac = "=0.13.0-rc.3"
+sha2 = { version = "=0.11.0-rc.3", default-features = false }
+aes-gcm = { version = "=0.11.0-rc.2", default-features = false, features = ["aes"] }
+digest = "=0.11.0-rc.5"
 heapless = { version = "0.9.2", default-features = false }
 embedded-io = "0.7.1"
 embedded-io-async = "0.7.0"
 embedded-io-adapters = { version = "0.7.0", optional = true }
 webpki = { package = "rustls-webpki", version = "0.103.8", default-features = false, optional = true }
 const-oid = { version = "0.10.2", optional = true }
-der = { version = "0.8.0-rc.10", features = ["derive", "oid", "time"], optional = true }
-signature = { version = "3.0.0-rc.6", default-features = false }
-ecdsa = { version = "0.17.0-rc.12", default-features = false }
+der = { version = "=0.8.0-rc.10", features = ["derive", "oid", "time"], optional = true }
+signature = { version = "=3.0.0-rc.6", default-features = false }
+ecdsa = { version = "=0.17.0-rc.12", default-features = false }
 
 # Logging alternatives
 log = { version = "0.4", optional = true }
@@ -46,7 +46,7 @@ mio = { version = "1.1.1", features = ["os-poll", "net"] }
 rustls = { version = "0.23.36", features = ["ring", "std"], default-features = false }
 rustls-pemfile = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
-rand = "0.10.0-rc.6"
+rand = "=0.10.0-rc.6"
 log = "0.4"
 pem-parser = "0.1.1"
 openssl = "0.10.75"

--- a/examples/blocking/Cargo.toml
+++ b/examples/blocking/Cargo.toml
@@ -13,5 +13,5 @@ embedded-io = { version = "0.7.0" }
 embedded-io-adapters = { version = "0.7.0", features = ["std"] }
 pem-parser = "0.1"
 env_logger = "0.10"
-rand = "0.8"
+rand = "=0.10.0-rc.6"
 log = "0.4"

--- a/examples/blocking/src/main.rs
+++ b/examples/blocking/src/main.rs
@@ -1,13 +1,12 @@
+use std::net::TcpStream;
+use std::time::SystemTime;
+
 use embedded_io::Write as _;
 use embedded_io_adapters::std::FromStd;
 use embedded_tls::blocking::*;
 use embedded_tls::webpki::CertVerifier;
-use rand::rngs::OsRng;
-use std::net::TcpStream;
-use std::time::SystemTime;
 
 struct Provider {
-    rng: OsRng,
     verifier: CertVerifier<Aes128GcmSha256, SystemTime, 4096>,
 }
 
@@ -16,8 +15,8 @@ impl CryptoProvider for Provider {
 
     type Signature = &'static [u8];
 
-    fn rng(&mut self) -> impl embedded_tls::CryptoRngCore {
-        &mut self.rng
+    fn rng(&mut self) -> impl embedded_tls::CryptoRng {
+        rand::rng()
     }
 
     fn verifier(
@@ -44,7 +43,6 @@ fn main() {
     tls.open(TlsContext::new(
         &config,
         Provider {
-            rng: OsRng,
             verifier: CertVerifier::new(),
         },
     ))

--- a/examples/embassy/Cargo.toml
+++ b/examples/embassy/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [dependencies]
 embedded-tls = { path = "../..", features = ["alloc", "std", "log"], default-features = false }
 env_logger = "0.10"
-rand = "0.8"
+rand = "=0.10.0-rc.6"
 log = "0.4"
 static_cell = "1"
 embassy-executor = { version = "0.9", features = ["arch-std", "executor-thread", "log"] }

--- a/examples/embassy/src/main.rs
+++ b/examples/embassy/src/main.rs
@@ -8,7 +8,7 @@ use embedded_io_async::Write;
 use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
 use heapless::Vec;
 use log::*;
-use rand::{rngs::OsRng, RngCore};
+use rand::RngCore;
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -47,7 +47,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    rand::rng().fill_bytes(&mut seed);
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
@@ -80,7 +80,7 @@ async fn main_task(spawner: Spawner) {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");

--- a/examples/tokio-psk/Cargo.toml
+++ b/examples/tokio-psk/Cargo.toml
@@ -9,6 +9,6 @@ embedded-io-adapters = { version = "0.7", features = ["tokio-1"] }
 embedded-io-async = "0.7"
 env_logger = "0.10"
 tokio = { version = "1", features = ["full"] }
-rand = "0.8"
+rand = "=0.10.0-rc.6"
 log = "0.4"
 pem-parser = "0.1.1"

--- a/examples/tokio-psk/src/main.rs
+++ b/examples/tokio-psk/src/main.rs
@@ -1,10 +1,10 @@
 #![macro_use]
 
+use std::error::Error;
+
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_io_async::Write as _;
 use embedded_tls::*;
-use rand::rngs::OsRng;
-use std::error::Error;
 use tokio::net::TcpStream;
 
 #[tokio::main]
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");

--- a/examples/tokio/Cargo.toml
+++ b/examples/tokio/Cargo.toml
@@ -13,6 +13,6 @@ embedded-io-adapters = { version = "0.7", features = ["tokio-1"] }
 embedded-io-async = "0.7"
 env_logger = "0.10"
 tokio = { version = "1", features = ["full"] }
-rand = "0.8"
+rand = "=0.10.0-rc.6"
 log = "0.4"
 pem-parser = "0.1.1"

--- a/examples/tokio/src/main.rs
+++ b/examples/tokio/src/main.rs
@@ -1,10 +1,10 @@
 #![macro_use]
 
+use std::error::Error;
+
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_io_async::Write as _;
 use embedded_tls::*;
-use rand::rngs::OsRng;
-use std::error::Error;
 use tokio::net::TcpStream;
 
 #[tokio::main]
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "stable"
+channel = "1.87"
 components = [ "rustfmt", "clippy" ]
 targets = [ "thumbv7em-none-eabi" ]

--- a/src/handshake/binder.rs
+++ b/src/handshake/binder.rs
@@ -1,28 +1,28 @@
+use core::fmt::{Debug, Formatter};
+
+use digest::array::{Array, ArraySize};
+
 use crate::TlsError;
 use crate::buffer::CryptoBuffer;
-use core::fmt::{Debug, Formatter};
-//use digest::generic_array::{ArrayLength, GenericArray};
-use generic_array::{ArrayLength, GenericArray};
-// use heapless::Vec;
 
-pub struct PskBinder<N: ArrayLength<u8>> {
-    pub verify: GenericArray<u8, N>,
+pub struct PskBinder<N: ArraySize> {
+    pub verify: Array<u8, N>,
 }
 
 #[cfg(feature = "defmt")]
-impl<N: ArrayLength<u8>> defmt::Format for PskBinder<N> {
+impl<N: ArraySize> defmt::Format for PskBinder<N> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f, "verify length:{}", &self.verify.len());
     }
 }
 
-impl<N: ArrayLength<u8>> Debug for PskBinder<N> {
+impl<N: ArraySize> Debug for PskBinder<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("PskBinder").finish()
     }
 }
 
-impl<N: ArrayLength<u8>> PskBinder<N> {
+impl<N: ArraySize> PskBinder<N> {
     pub(crate) fn encode(&self, buf: &mut CryptoBuffer<'_>) -> Result<(), TlsError> {
         let len = self.verify.len() as u8;
         //buf.extend_from_slice(&[len[1], len[2], len[3]]);

--- a/src/handshake/certificate.rs
+++ b/src/handshake/certificate.rs
@@ -1,8 +1,9 @@
+use heapless::Vec;
+
 use crate::TlsError;
 use crate::buffer::CryptoBuffer;
 use crate::extensions::messages::CertificateExtension;
 use crate::parse_buffer::ParseBuffer;
-use heapless::Vec;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/handshake/certificate_request.rs
+++ b/src/handshake/certificate_request.rs
@@ -1,7 +1,8 @@
+use heapless::Vec;
+
 use crate::extensions::messages::CertificateRequestExtension;
 use crate::parse_buffer::ParseBuffer;
 use crate::{TlsError, unused};
-use heapless::Vec;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/handshake/client_hello.rs
+++ b/src/handshake/client_hello.rs
@@ -1,11 +1,12 @@
 use core::marker::PhantomData;
 
+use digest::typenum::Unsigned;
 use digest::{Digest, OutputSizeUser};
 use heapless::Vec;
 use p256::EncodedPoint;
 use p256::ecdh::EphemeralSecret;
+use p256::elliptic_curve::Generate;
 use p256::elliptic_curve::rand_core::RngCore;
-use typenum::Unsigned;
 
 use crate::TlsError;
 use crate::config::{TlsCipherSuite, TlsConfig};
@@ -48,7 +49,7 @@ where
             config,
             random,
             cipher_suite: PhantomData,
-            secret: EphemeralSecret::random(&mut provider.rng()),
+            secret: EphemeralSecret::generate_from_rng(&mut provider.rng()),
         }
     }
 

--- a/src/handshake/finished.rs
+++ b/src/handshake/finished.rs
@@ -1,24 +1,24 @@
+use core::fmt::{Debug, Formatter};
+
+use digest::array::{Array, ArraySize};
+
 use crate::TlsError;
 use crate::buffer::CryptoBuffer;
 use crate::parse_buffer::ParseBuffer;
-use core::fmt::{Debug, Formatter};
-//use digest::generic_array::{ArrayLength, GenericArray};
-use generic_array::{ArrayLength, GenericArray};
-// use heapless::Vec;
 
-pub struct Finished<N: ArrayLength<u8>> {
-    pub verify: GenericArray<u8, N>,
-    pub hash: Option<GenericArray<u8, N>>,
+pub struct Finished<N: ArraySize> {
+    pub verify: Array<u8, N>,
+    pub hash: Option<Array<u8, N>>,
 }
 
 #[cfg(feature = "defmt")]
-impl<N: ArrayLength<u8>> defmt::Format for Finished<N> {
+impl<N: ArraySize> defmt::Format for Finished<N> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f, "verify length:{}", &self.verify.len());
     }
 }
 
-impl<N: ArrayLength<u8>> Debug for Finished<N> {
+impl<N: ArraySize> Debug for Finished<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Finished")
             .field("verify", &self.hash)
@@ -26,12 +26,12 @@ impl<N: ArrayLength<u8>> Debug for Finished<N> {
     }
 }
 
-impl<N: ArrayLength<u8>> Finished<N> {
+impl<N: ArraySize> Finished<N> {
     pub fn parse(buf: &mut ParseBuffer, _len: u32) -> Result<Self, TlsError> {
         // info!("finished len: {}", len);
-        let mut verify = GenericArray::default();
+        let mut verify = Array::default();
         buf.fill(&mut verify)?;
-        //let hash = GenericArray::from_slice()
+        //let hash = Array::from_slice()
         //let hash: Result<Vec<u8, _>, ()> = buf
         //.slice(len as usize)
         //.map_err(|_| TlsError::InvalidHandshake)?

--- a/src/parse_buffer.rs
+++ b/src/parse_buffer.rs
@@ -1,5 +1,6 @@
-use crate::TlsError;
 use heapless::{CapacityError, Vec};
+
+use crate::TlsError;
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -181,6 +181,7 @@ fn verify_signature(
     match verify.signature_scheme {
         SignatureScheme::EcdsaSecp256r1Sha256 => {
             use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
             let verifying_key =
                 VerifyingKey::from_sec1_bytes(public_key).map_err(|_| TlsError::DecodeError)?;
             let signature =
@@ -190,6 +191,7 @@ fn verify_signature(
         #[cfg(feature = "p384")]
         SignatureScheme::EcdsaSecp384r1Sha384 => {
             use p384::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
             let verifying_key =
                 VerifyingKey::from_sec1_bytes(public_key).map_err(|_| TlsError::DecodeError)?;
             let signature =
@@ -198,10 +200,12 @@ fn verify_signature(
         }
         #[cfg(feature = "ed25519")]
         SignatureScheme::Ed25519 => {
-            use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+            use ed25519_dalek::{PUBLIC_KEY_LENGTH, Signature, Verifier, VerifyingKey};
+
+            let public_key = <&[u8; PUBLIC_KEY_LENGTH]>::try_from(public_key)
+                .map_err(|_| TlsError::DecodeError)?;
             let verifying_key: VerifyingKey =
-                VerifyingKey::from_bytes(public_key.try_into().unwrap())
-                    .map_err(|_| TlsError::DecodeError)?;
+                VerifyingKey::from_bytes(public_key).map_err(|_| TlsError::DecodeError)?;
             let signature =
                 Signature::try_from(verify.signature).map_err(|_| TlsError::DecodeError)?;
             verified = verifying_key.verify(message, &signature).is_ok();
@@ -216,7 +220,8 @@ fn verify_signature(
             };
             use sha2::Sha256;
 
-            let der_pubkey = RsaPublicKey::from_pkcs1_der(public_key).unwrap();
+            let der_pubkey =
+                RsaPublicKey::from_pkcs1_der(public_key).map_err(|_| TlsError::DecodeError)?;
             let verifying_key = VerifyingKey::<Sha256>::from(der_pubkey);
 
             let signature =
@@ -348,6 +353,7 @@ fn verify_certificate(
         match parsed_certificate.signature_algorithm {
             ECDSA_SHA256 => {
                 use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
                 let verifying_key = VerifyingKey::from_sec1_bytes(ca_public_key)
                     .map_err(|_| TlsError::DecodeError)?;
 
@@ -364,6 +370,7 @@ fn verify_certificate(
             #[cfg(feature = "p384")]
             ECDSA_SHA384 => {
                 use p384::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
                 let verifying_key = VerifyingKey::from_sec1_bytes(ca_public_key)
                     .map_err(|_| TlsError::DecodeError)?;
 
@@ -379,10 +386,12 @@ fn verify_certificate(
             }
             #[cfg(feature = "ed25519")]
             ED25519 => {
-                use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+                use ed25519_dalek::{PUBLIC_KEY_LENGTH, Signature, Verifier, VerifyingKey};
+
+                let ca_public_key = <&[u8; PUBLIC_KEY_LENGTH]>::try_from(ca_public_key)
+                    .map_err(|_| TlsError::DecodeError)?;
                 let verifying_key: VerifyingKey =
-                    VerifyingKey::from_bytes(ca_public_key.try_into().unwrap())
-                        .map_err(|_| TlsError::DecodeError)?;
+                    VerifyingKey::from_bytes(ca_public_key).map_err(|_| TlsError::DecodeError)?;
 
                 let signature = Signature::try_from(
                     parsed_certificate
@@ -404,7 +413,8 @@ fn verify_certificate(
                 };
                 use sha2::Sha256;
 
-                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key).unwrap();
+                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key)
+                    .map_err(|_| TlsError::DecodeError)?;
                 let verifying_key = VerifyingKey::<Sha256>::from(der_pubkey);
 
                 let signature = Signature::try_from(
@@ -430,7 +440,8 @@ fn verify_certificate(
                 };
                 use sha2::Sha384;
 
-                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key).unwrap();
+                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key)
+                    .map_err(|_| TlsError::DecodeError)?;
                 let verifying_key = VerifyingKey::<Sha384>::from(der_pubkey);
 
                 let signature = Signature::try_from(
@@ -453,7 +464,8 @@ fn verify_certificate(
                 };
                 use sha2::Sha512;
 
-                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key).unwrap();
+                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key)
+                    .map_err(|_| TlsError::DecodeError)?;
                 let verifying_key = VerifyingKey::<Sha512>::from(der_pubkey);
 
                 let signature = Signature::try_from(

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -397,17 +397,15 @@ fn verify_certificate(
             #[cfg(feature = "rsa")]
             a if a == RSA_PKCS1_SHA256 => {
                 use rsa::{
+                    RsaPublicKey,
                     pkcs1::DecodeRsaPublicKey,
                     pkcs1v15::{Signature, VerifyingKey},
                     signature::Verifier,
                 };
                 use sha2::Sha256;
 
-                let verifying_key =
-                    VerifyingKey::<Sha256>::from_pkcs1_der(ca_public_key).map_err(|e| {
-                        error!("VerifyingKey: {}", e);
-                        TlsError::DecodeError
-                    })?;
+                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key).unwrap();
+                let verifying_key = VerifyingKey::<Sha256>::from(der_pubkey);
 
                 let signature = Signature::try_from(
                     parsed_certificate
@@ -425,14 +423,15 @@ fn verify_certificate(
             #[cfg(feature = "rsa")]
             a if a == RSA_PKCS1_SHA384 => {
                 use rsa::{
+                    RsaPublicKey,
                     pkcs1::DecodeRsaPublicKey,
                     pkcs1v15::{Signature, VerifyingKey},
                     signature::Verifier,
                 };
                 use sha2::Sha384;
 
-                let verifying_key = VerifyingKey::<Sha384>::from_pkcs1_der(ca_public_key)
-                    .map_err(|_| TlsError::DecodeError)?;
+                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key).unwrap();
+                let verifying_key = VerifyingKey::<Sha384>::from(der_pubkey);
 
                 let signature = Signature::try_from(
                     parsed_certificate
@@ -447,14 +446,15 @@ fn verify_certificate(
             #[cfg(feature = "rsa")]
             a if a == RSA_PKCS1_SHA512 => {
                 use rsa::{
+                    RsaPublicKey,
                     pkcs1::DecodeRsaPublicKey,
                     pkcs1v15::{Signature, VerifyingKey},
                     signature::Verifier,
                 };
                 use sha2::Sha512;
 
-                let verifying_key = VerifyingKey::<Sha512>::from_pkcs1_der(ca_public_key)
-                    .map_err(|_| TlsError::DecodeError)?;
+                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key).unwrap();
+                let verifying_key = VerifyingKey::<Sha512>::from(der_pubkey);
 
                 let signature = Signature::try_from(
                     parsed_certificate

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,3 +1,5 @@
+use core::fmt::Debug;
+
 use crate::TlsError;
 use crate::application_data::ApplicationData;
 use crate::change_cipher_spec::ChangeCipherSpec;
@@ -11,14 +13,12 @@ use crate::{
     alert::{Alert, AlertDescription, AlertLevel},
     parse_buffer::ParseBuffer,
 };
-use core::fmt::Debug;
 
 pub type Encrypted = bool;
 
 #[allow(clippy::large_enum_variant)]
 pub enum ClientRecord<'config, 'a, CipherSuite>
 where
-    // N: ArrayLength<u8>,
     CipherSuite: TlsCipherSuite,
 {
     Handshake(ClientHandshake<'config, 'a, CipherSuite>, Encrypted),
@@ -80,7 +80,6 @@ impl ClientRecordHeader {
 
 impl<'config, CipherSuite> ClientRecord<'config, '_, CipherSuite>
 where
-    //N: ArrayLength<u8>,
     CipherSuite: TlsCipherSuite,
 {
     pub fn header(&self) -> ClientRecordHeader {

--- a/tests/client_cert_test.rs
+++ b/tests/client_cert_test.rs
@@ -1,29 +1,23 @@
+use std::net::SocketAddr;
+use std::sync::{Arc, OnceLock};
+
 use ecdsa::elliptic_curve::SecretKey;
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_tls::{CryptoProvider, SignatureScheme};
 use p256::ecdsa::SigningKey;
-use rand::rngs::OsRng;
-use rand_core::CryptoRngCore;
-use rustls::server::AllowAnyAuthenticatedClient;
-use std::net::SocketAddr;
-use std::sync::Once;
+use rand_core::CryptoRng;
+use rustls::server::WebPkiClientVerifier;
 
 mod tlsserver;
 
-static LOG_INIT: Once = Once::new();
-static INIT: Once = Once::new();
-static mut ADDR: Option<SocketAddr> = None;
-
-fn init_log() {
-    LOG_INIT.call_once(|| {
-        env_logger::init();
-    });
-}
+static ADDR: OnceLock<SocketAddr> = OnceLock::new();
 
 fn setup() -> SocketAddr {
     use mio::net::TcpListener;
-    init_log();
-    INIT.call_once(|| {
+
+    *ADDR.get_or_init(|| {
+        env_logger::init();
+
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
 
         let listener = TcpListener::bind(addr).expect("cannot listen on port");
@@ -34,8 +28,6 @@ fn setup() -> SocketAddr {
         std::thread::spawn(move || {
             use tlsserver::*;
 
-            let versions = &[&rustls::version::TLS13];
-
             let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
             let ca = load_certs(&test_dir.join("data").join("ca-cert.pem"));
@@ -43,48 +35,41 @@ fn setup() -> SocketAddr {
             let privkey = load_private_key(&test_dir.join("data").join("server-key.pem"));
 
             let mut client_auth_roots = rustls::RootCertStore::empty();
-            for root in ca.iter() {
+            for root in ca.into_iter() {
                 client_auth_roots.add(root).unwrap()
             }
 
-            let client_cert_verifier = AllowAnyAuthenticatedClient::new(client_auth_roots);
+            let client_cert_verifier = WebPkiClientVerifier::builder(Arc::new(client_auth_roots))
+                .build()
+                .unwrap();
 
             let config = rustls::ServerConfig::builder()
-                .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
-                .with_kx_groups(&rustls::ALL_KX_GROUPS)
-                .with_protocol_versions(versions)
-                .unwrap()
-                .with_client_cert_verifier(client_cert_verifier.boxed())
+                .with_client_cert_verifier(client_cert_verifier)
                 .with_single_cert(certs, privkey)
                 .unwrap();
 
             run_with_config(listener, config);
         });
-        #[allow(static_mut_refs)]
-        unsafe {
-            ADDR.replace(addr)
-        };
-    });
-    unsafe { ADDR.unwrap() }
+
+        addr
+    })
 }
 
 #[derive(Default)]
-struct Provider {
-    rng: OsRng,
-}
+struct Provider;
 
 impl CryptoProvider for Provider {
     type CipherSuite = embedded_tls::Aes128GcmSha256;
     type Signature = p256::ecdsa::DerSignature;
 
-    fn rng(&mut self) -> impl CryptoRngCore {
-        &mut self.rng
+    fn rng(&mut self) -> impl CryptoRng {
+        rand::rng()
     }
 
     fn signer(
         &mut self,
         key_der: &[u8],
-    ) -> Result<(impl signature::SignerMut<Self::Signature>, SignatureScheme), embedded_tls::TlsError>
+    ) -> Result<(impl signature::Signer<Self::Signature>, SignatureScheme), embedded_tls::TlsError>
     {
         let secret_key = SecretKey::from_sec1_der(key_der)
             .map_err(|_| embedded_tls::TlsError::InvalidPrivateKey)?;

--- a/tests/early_data_test.rs
+++ b/tests/early_data_test.rs
@@ -1,18 +1,19 @@
 #![macro_use]
+
+use std::net::SocketAddr;
+use std::sync::OnceLock;
+
 use embedded_io::{Read, Write};
 use embedded_io_adapters::std::FromStd;
-use rand_core::OsRng;
-use std::net::SocketAddr;
-use std::sync::Once;
 
 mod tlsserver;
 
-static INIT: Once = Once::new();
-static mut ADDR: Option<SocketAddr> = None;
+static ADDR: OnceLock<SocketAddr> = OnceLock::new();
 
 fn setup() -> SocketAddr {
     use mio::net::TcpListener;
-    INIT.call_once(|| {
+
+    *ADDR.get_or_init(|| {
         env_logger::init();
 
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
@@ -25,18 +26,12 @@ fn setup() -> SocketAddr {
         std::thread::spawn(move || {
             use tlsserver::*;
 
-            let versions = &[&rustls::version::TLS13];
-
             let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
             let certs = load_certs(&test_dir.join("data").join("server-cert.pem"));
             let privkey = load_private_key(&test_dir.join("data").join("server-key.pem"));
 
             let mut config = rustls::ServerConfig::builder()
-                .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
-                .with_kx_groups(&rustls::ALL_KX_GROUPS)
-                .with_protocol_versions(versions)
-                .unwrap()
                 .with_no_client_auth()
                 .with_single_cert(certs, privkey)
                 .unwrap();
@@ -45,12 +40,9 @@ fn setup() -> SocketAddr {
 
             run_with_config(listener, config);
         });
-        #[allow(static_mut_refs)]
-        unsafe {
-            ADDR.replace(addr)
-        };
-    });
-    unsafe { ADDR.unwrap() }
+
+        addr
+    })
 }
 
 #[test]
@@ -79,7 +71,7 @@ fn early_data_ignored() {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .expect("error establishing TLS connection");
 

--- a/tests/psk_test.rs
+++ b/tests/psk_test.rs
@@ -1,12 +1,13 @@
 #![macro_use]
-use embedded_io_adapters::tokio_1::FromTokio;
-use embedded_tls::*;
-use openssl::ssl;
-use rand::rngs::OsRng;
+
 use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::net::TcpListener;
 use std::sync::Once;
+
+use embedded_io_adapters::tokio_1::FromTokio;
+use embedded_tls::*;
+use openssl::ssl;
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
@@ -84,7 +85,7 @@ async fn test_psk_open() {
         assert!(
             tls.open(TlsContext::new(
                 &config,
-                UnsecureProvider::new::<Aes128GcmSha256>(OsRng)
+                UnsecureProvider::new::<Aes128GcmSha256>(rand::rng())
             ))
             .await
             .is_ok()

--- a/tests/tlsserver.rs
+++ b/tests/tlsserver.rs
@@ -1,12 +1,11 @@
-use std::{path::PathBuf, sync::Arc};
-
-use mio::net::{TcpListener, TcpStream};
-
 use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::io::{BufReader, Read, Write};
 use std::net;
+use std::{path::PathBuf, sync::Arc};
+
+use mio::net::{TcpListener, TcpStream};
 
 // Token for our listening socket.
 pub const LISTENER: mio::Token = mio::Token(0);
@@ -324,25 +323,29 @@ impl Connection {
     }
 }
 
-pub fn load_certs(filename: &PathBuf) -> Vec<rustls::Certificate> {
+pub fn load_certs(filename: &PathBuf) -> Vec<rustls::pki_types::CertificateDer<'static>> {
     let certfile = fs::File::open(filename).expect("cannot open certificate file");
     let mut reader = BufReader::new(certfile);
     rustls_pemfile::certs(&mut reader)
-        .unwrap()
-        .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| v.unwrap())
         .collect()
 }
 
-pub fn load_private_key(filename: &PathBuf) -> rustls::PrivateKey {
+pub fn load_private_key(filename: &PathBuf) -> rustls::pki_types::PrivateKeyDer<'static> {
     let keyfile = fs::File::open(filename).expect("cannot open private key file");
     let mut reader = BufReader::new(keyfile);
 
     loop {
         match rustls_pemfile::read_one(&mut reader).expect("cannot parse private key .pem file") {
-            Some(rustls_pemfile::Item::RSAKey(key)) => return rustls::PrivateKey(key),
-            Some(rustls_pemfile::Item::PKCS8Key(key)) => return rustls::PrivateKey(key),
-            Some(rustls_pemfile::Item::ECKey(key)) => return rustls::PrivateKey(key),
+            Some(rustls_pemfile::Item::Pkcs1Key(key)) => {
+                return rustls::pki_types::PrivateKeyDer::Pkcs1(key);
+            }
+            Some(rustls_pemfile::Item::Pkcs8Key(key)) => {
+                return rustls::pki_types::PrivateKeyDer::Pkcs8(key);
+            }
+            Some(rustls_pemfile::Item::Sec1Key(key)) => {
+                return rustls::pki_types::PrivateKeyDer::Sec1(key);
+            }
             None => break,
             _ => {}
         }
@@ -356,18 +359,12 @@ pub fn load_private_key(filename: &PathBuf) -> rustls::PrivateKey {
 
 #[allow(dead_code)]
 pub fn run(listener: TcpListener) {
-    let versions = &[&rustls::version::TLS13];
-
     let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
     let certs = load_certs(&test_dir.join("data").join("server-cert.pem"));
     let privkey = load_private_key(&test_dir.join("data").join("server-key.pem"));
 
     let config = rustls::ServerConfig::builder()
-        .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
-        .with_kx_groups(&rustls::ALL_KX_GROUPS)
-        .with_protocol_versions(versions)
-        .unwrap()
         .with_no_client_auth()
         .with_single_cert(certs, privkey)
         .unwrap();

--- a/tests/webpki_test.rs
+++ b/tests/webpki_test.rs
@@ -1,11 +1,12 @@
 #![cfg(feature = "webpki")]
 
-use embedded_io_adapters::tokio_1::FromTokio;
-use embedded_tls::webpki::CertVerifier;
-use embedded_tls::{Aes128GcmSha256, CryptoProvider, TlsVerifier};
 use std::net::SocketAddr;
 use std::sync::OnceLock;
 use std::time::SystemTime;
+
+use embedded_io_adapters::tokio_1::FromTokio;
+use embedded_tls::webpki::CertVerifier;
+use embedded_tls::{Aes128GcmSha256, CryptoProvider, TlsVerifier};
 
 mod tlsserver;
 
@@ -13,7 +14,6 @@ static LOG_INIT: OnceLock<()> = OnceLock::new();
 
 #[derive(Default)]
 struct WebPkiProvider {
-    rng: rand::rngs::OsRng,
     verifier: CertVerifier<Aes128GcmSha256, SystemTime, 4096>,
 }
 
@@ -21,8 +21,8 @@ impl CryptoProvider for WebPkiProvider {
     type CipherSuite = Aes128GcmSha256;
     type Signature = &'static [u8];
 
-    fn rng(&mut self) -> impl embedded_tls::CryptoRngCore {
-        &mut self.rng
+    fn rng(&mut self) -> impl embedded_tls::CryptoRng {
+        rand::rng()
     }
 
     fn verifier(

--- a/tests/webpki_test.rs
+++ b/tests/webpki_test.rs
@@ -7,6 +7,7 @@ use std::time::SystemTime;
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_tls::webpki::CertVerifier;
 use embedded_tls::{Aes128GcmSha256, CryptoProvider, TlsVerifier};
+use rand_core::CryptoRng;
 
 mod tlsserver;
 
@@ -21,7 +22,7 @@ impl CryptoProvider for WebPkiProvider {
     type CipherSuite = Aes128GcmSha256;
     type Signature = &'static [u8];
 
-    fn rng(&mut self) -> impl embedded_tls::CryptoRng {
+    fn rng(&mut self) -> impl CryptoRng {
         rand::rng()
     }
 


### PR DESCRIPTION
This supersedes my earlier attempt in #164.

Some crates have been released as final versions in the meantime, so I don't need to source dependencies from particular Git revisions anymore.
The RustCrypto crates are still only available as RCs. However, embedded-tls in its currently released version 0.18.0 already depends on `der 0.8.0-rc.2`. Hence, we could as well upgrade all RustCrypto dependencies to their latest RCs.

Like my earlier attempt in #164, this PR also eliminates the duplicate `heapless` dependency and all occurrences of `unsafe` in example code.
I've successfully validated my PR using `cargo test`.

I'd argue the best time to apply this PR is now :)
You just finished the 0.18.0 release, so `main` should be open for breaking changes again. As the next major release is probably a few months away, these changes have maximum time to be tested. Chances are also high that the RustCrypto crates are available in final versions by then.

CC @bugadani @lulf @newAM