### PR TITLE
Generate docs for most features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ license = "Apache-2.0"
 keywords = ["embedded", "async", "tls", "no_std", "network"]
 exclude = [".github"]
 
+[package.metadata.docs.rs]
+features = ["webpki", "rustpki", "rsa", "ed25519", "p384"]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 portable-atomic = { version = "1.6.0", default-features = false }
 p256 = { version = "0.13", default-features = false, features = [ "ecdh", "ecdsa", "sha256" ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
     clippy::cast_sign_loss,
     clippy::missing_errors_doc // TODO
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /*!
 # Example


### PR DESCRIPTION
The documentation generated on docs.rs currently lacks information about which code is feature-gated, and doesn't include docs for optional code that isn't compiled by default.

Use the following command to test this locally
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features webpki,rustpki,rsa,ed25519,p384 --no-deps