### PR TITLE
Remove heapless 0.6 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ aes-gcm = { version = "0.10.1", default-features = false, features = ["aes"] }
 digest = { version = "0.10.3", default-features = false, features = [ "core-api" ] }
 typenum = { version = "1.15.0", default-features = false }
 heapless = { version = "0.9", default-features = false }
-heapless_typenum = { package = "heapless", version = "0.6", default-features = false }
 embedded-io = "0.7"
 embedded-io-async = "0.7"
 embedded-io-adapters = { version = "0.7", optional = true }

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -9,7 +9,6 @@ use sha2::digest::generic_array::{GenericArray, typenum::Unsigned};
 
 pub type HashOutputSize<CipherSuite> =
     <<CipherSuite as TlsCipherSuite>::Hash as OutputSizeUser>::OutputSize;
-pub type LabelBufferSize<CipherSuite> = <CipherSuite as TlsCipherSuite>::LabelBufferSize;
 
 pub type IvArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::IvLen>;
 pub type KeyArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::KeyLen>;
@@ -49,21 +48,22 @@ where
         context_type: ContextType<CipherSuite>,
     ) -> Result<GenericArray<u8, N>, TlsError> {
         //info!("make label {:?} {}", label, len);
-        let mut hkdf_label = heapless_typenum::Vec::<u8, LabelBufferSize<CipherSuite>>::new();
+        // Max label buffer: hash_output (up to 48 for SHA-384) + 12 (longest label) + 10 (overhead) = 70
+        let mut hkdf_label = heapless::Vec::<u8, 70>::new();
         hkdf_label
             .extend_from_slice(&N::to_u16().to_be_bytes())
-            .map_err(|()| TlsError::InternalError)?;
+            .map_err(|_| TlsError::InternalError)?;
 
         let label_len = 6 + label.len() as u8;
         hkdf_label
             .extend_from_slice(&label_len.to_be_bytes())
-            .map_err(|()| TlsError::InternalError)?;
+            .map_err(|_| TlsError::InternalError)?;
         hkdf_label
             .extend_from_slice(b"tls13 ")
-            .map_err(|()| TlsError::InternalError)?;
+            .map_err(|_| TlsError::InternalError)?;
         hkdf_label
             .extend_from_slice(label)
-            .map_err(|()| TlsError::InternalError)?;
+            .map_err(|_| TlsError::InternalError)?;
 
         match context_type {
             ContextType::None => {
@@ -72,10 +72,10 @@ where
             ContextType::Hash(context) => {
                 hkdf_label
                     .extend_from_slice(&(context.len() as u8).to_be_bytes())
-                    .map_err(|()| TlsError::InternalError)?;
+                    .map_err(|_| TlsError::InternalError)?;
                 hkdf_label
                     .extend_from_slice(&context)
-                    .map_err(|()| TlsError::InternalError)?;
+                    .map_err(|_| TlsError::InternalError)?;
             }
         }
 


### PR DESCRIPTION
Replace the single use of `heapless_typenum` (heapless 0.6) in key_schedule.rs with `heapless` 0.9's const-generic Vec. The label buffer size has a known upper bound of 70 bytes (SHA-384 output 48 + longest label 12 + overhead 10), so a fixed const generic is safe and eliminates the need for a second heapless version.

On the one hand this change "wastes" 16 bytes on the stack when processing SHA256 hashes (since we leave room for the SHA384 case). On the other hand this removes 5 transitive dependencies from the tree:
- heapless 0.6
- as-slice
- generic-array 0.12
- generic-array 0.13
- hash32 0.1

The type of the error returned by extend_from_slice changed from heapless 0.6 to 0.9, so most of the code change is just fixing up the error mapping.